### PR TITLE
Fix PostCSS ES module error

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- use ESM export syntax in `tailwind.config.js`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*