### PR TITLE
Fix PostCSS config for Vite

### DIFF
--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
## Summary
- rename PostCSS config to `.cjs`
- export configuration with `module.exports`

## Testing
- `git status --short`