### PR TITLE
Fix API proxy and add dev instructions

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,18 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Local development
+
+Run the FastAPI backend on port `8000` and start the React dev server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The Vite dev server proxies `/api` requests to `http://localhost:8000` (configured in `vite.config.ts`).
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- make React dev server proxy `/api` requests to the backend
- document how to run the frontend with the backend

## Testing
- `poetry install -v` *(fails: could not connect to pypi.org)*