### PR TITLE
Fix BaseSettings import for Pydantic v2

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -5,7 +5,11 @@ from functools import lru_cache
 from pathlib import Path
 from typing import List, Optional
 
-from pydantic import BaseSettings, Field, validator
+try:
+    from pydantic_settings import BaseSettings
+except ImportError:  # pragma: no cover - fallback for Pydantic<2.0
+    from pydantic import BaseSettings
+from pydantic import Field, validator
 
 # <repo‑root>/backend/app/core/config.py  →  repo root is three parents up
 BASE_DIR = Path(__file__).resolve().parents[2]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,7 +12,8 @@ packages = [
 python = "^3.9" # Or your preferred Python version
 fastapi = "^0.100.0"
 uvicorn = {extras = ["standard"], version = "^0.23.2"}
-pydantic = "^1.10"
+pydantic = "^2.11"
+pydantic-settings = "^2.9"
 psycopg2-binary = "^2.9.6" # For PostgreSQL
 python-jose = {extras = ["cryptography"], version = "^3.3.0"} # For JWTs if needed
 passlib = {extras = ["bcrypt"], version = "^1.7.4"} # For password hashing if needed


### PR DESCRIPTION
## Summary
- import `BaseSettings` from `pydantic_settings` with fallback
- bump to pydantic 2 in the backend dependencies
- add pydantic-settings dependency

## Testing
- `ruff check .` *(fails: unsorted imports and other lint errors)*
- `pytest -q` *(fails: command not found)*