### PR TITLE
Fix strategy engine errors

### DIFF
--- a/backend/app/services/strategy_engine/strategies/base_strategy.py
+++ b/backend/app/services/strategy_engine/strategies/base_strategy.py
@@ -103,7 +103,7 @@ class BaseStrategy(ABC):
                     ),
                     total_tax_paid=float(y.total_tax),
                     after_tax_income=float(y.after_tax_income),
-                    oas_net_received=float(y.oas_net),
+                    oas_net_received=float(max(y.oas_net, 0)),
                     actual_spending=float(y.spending),
                     end_rrif_balance=float(y.end_rrif),
                     end_tfsa_balance=float(y.end_tfsa),

--- a/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
+++ b/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
@@ -92,7 +92,7 @@ class DelayCppOasStrategy(BaseStrategy):
         min_rrif = Decimal(
             str(
                 tax_rules.get_rrif_min_withdrawal_amount(
-                    float(begin_rrif), age
+                    float(begin_rrif), age, td
                 )
             )
         )

--- a/backend/app/services/strategy_engine/strategies/early_rrif_conversion.py
+++ b/backend/app/services/strategy_engine/strategies/early_rrif_conversion.py
@@ -70,7 +70,7 @@ class EarlyRRIFConversionStrategy(BaseStrategy):
             gross_rrif = Decimal(
                 str(
                     tax_rules.get_rrif_min_withdrawal_amount(
-                        float(begin_rrif), age
+                        float(begin_rrif), age, td
                     )
                 )
             )

--- a/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
+++ b/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
@@ -53,7 +53,11 @@ class InterestOffsetStrategy(BaseStrategy):
 
         # ---------- CRA minimum withdrawal ------------------------- #
         min_rrif = Decimal(
-            str(tax_rules.get_rrif_min_withdrawal_amount(float(begin_rrif), age))
+            str(
+                tax_rules.get_rrif_min_withdrawal_amount(
+                    float(begin_rrif), age, td
+                )
+            )
         )
 
         # ---------- spending target (real) ------------------------- #

--- a/backend/app/services/strategy_engine/strategies/lump_sum_withdrawal.py
+++ b/backend/app/services/strategy_engine/strategies/lump_sum_withdrawal.py
@@ -33,6 +33,9 @@ class LumpSumWithdrawalStrategy(BaseStrategy):
     # alias for backward compatibility / tests
     pass
 
+    def run_year(self, idx: int, state: EngineState) -> None:
+        _run_year(self, idx, state)
+
 
 # Keep the implementation outside the class body, then mix in
 def _run_year(self: LumpSumWithdrawalStrategy, idx: int, state: EngineState) -> None:
@@ -57,7 +60,11 @@ def _run_year(self: LumpSumWithdrawalStrategy, idx: int, state: EngineState) -> 
 
     # -------------- CRA minimum withdrawal ------------------------ #
     min_rrif = Decimal(
-        str(tax_rules.get_rrif_min_withdrawal_amount(float(begin_rrif), age))
+        str(
+            tax_rules.get_rrif_min_withdrawal_amount(
+                float(begin_rrif), age, td
+            )
+        )
     )
 
     # -------------- Binary‑search withdrawal to hit spend target --- #
@@ -162,11 +169,6 @@ def _run_year(self: LumpSumWithdrawalStrategy, idx: int, state: EngineState) -> 
             end_non_reg=end_non,
         )
     )
-
-
-# bind method to class (so we didn’t indent a 300‑line class body)
-LumpSumWithdrawalStrategy.run_year = _run_year  # type: ignore[attr-defined}
-
 # backward‑compat alias
 LumpSumStrategy = LumpSumWithdrawalStrategy
 

--- a/backend/app/services/strategy_engine/strategies/spousal_equalization.py
+++ b/backend/app/services/strategy_engine/strategies/spousal_equalization.py
@@ -53,7 +53,7 @@ class SpousalEqualizationStrategy(BaseStrategy):
             )
 
             fallback = GradualMeltdownStrategy(
-                self.scenario, self.params, self.tax_loader
+                self.scenario, self.params, self._tax_loader
             )
             return fallback.run_year(idx, state)
 


### PR DESCRIPTION
## Summary
- fix negative OAS result construction
- pass tax data to RRIF minimum function
- propagate tax loader for spousal fallback
- expose `run_year` on lump sum strategy

## Testing
- `poetry run pytest -q` *(fails: Command not found)*