### PR TITLE
Fix import order and unused reference

### DIFF
--- a/backend/app/data_models/results.py
+++ b/backend/app/data_models/results.py
@@ -182,6 +182,9 @@ class SummaryMetrics(BaseModel):
     strategy_complexity_score: conint(ge=1, le=5) = Field(
         ..., description="Subjective score of strategy complexity (1=simple, 5=complex)."
     )
+    horizon_years: conint(ge=1) = Field(
+        ..., description="Number of years in the projection horizon."
+    )
 
     class Config:
         json_schema_extra = {
@@ -202,7 +205,8 @@ class SummaryMetrics(BaseModel):
                 "final_total_portfolio_value_pv": 150000.00,
                 "net_value_to_heirs_after_final_taxes_pv": 120000.00,
                 "sequence_risk_score": 75000.00,
-                "strategy_complexity_score": 2
+                "strategy_complexity_score": 2,
+                "horizon_years": 30
             }
         }
 

--- a/backend/app/services/strategy_engine/strategies/base_strategy.py
+++ b/backend/app/services/strategy_engine/strategies/base_strategy.py
@@ -21,19 +21,21 @@ from abc import ABC, abstractmethod
 from decimal import Decimal
 from typing import List
 
-from app.data_models.scenario import (
-    ScenarioInput,
-    StrategyParamsInput,
-    StrategyCodeEnum,
-)
 from app.data_models.results import (
     IncomeSources,
     SummaryMetrics,
     TaxBreakdown,
     YearlyResult,
 )
+from app.data_models.scenario import (
+    ScenarioInput,
+    StrategyCodeEnum,
+    StrategyParamsInput,
+)
+from app.services.strategy_engine.state import (  # ensure this file exists
+    EngineState,
+)
 from app.services.strategy_engine.tax_rules import TaxYearData
-from app.services.strategy_engine.state import EngineState, YearScratch  # ensure this file exists
 
 # real discount rate used for PV calcs (2 % after inflation)
 REAL_DISCOUNT_RATE = Decimal("0.02")
@@ -153,4 +155,5 @@ class BaseStrategy(ABC):
             net_value_to_heirs_after_final_taxes_pv=end_bal,
             sequence_risk_score=None,
             strategy_complexity_score=self.complexity,
+            horizon_years=len(yearly),
         )

--- a/backend/app/services/strategy_engine/tax_rules.py
+++ b/backend/app/services/strategy_engine/tax_rules.py
@@ -250,3 +250,10 @@ def eligible_pension_income(age: int, rrif_withdrawal: float, db_pension: float)
     """RRIF income qualifies for the credit at 65+."""
     return db_pension + (rrif_withdrawal if age >= 65 else 0.0)
 
+
+def get_eligible_pension_income_for_credit(
+    rrif_withdrawal: float, db_pension_income: float, age: int
+) -> float:
+    """Compatibility wrapper returning pension income eligible for the credit."""
+    return eligible_pension_income(age, rrif_withdrawal, db_pension_income)
+


### PR DESCRIPTION
## Summary
- add `horizon_years` metric and expose pension credit helper
- include new metric in strategy summaries
- clean up base strategy imports

## Testing
- `ruff check app/data_models/results.py app/services/strategy_engine/strategies/base_strategy.py app/services/strategy_engine/tax_rules.py`
- `pytest -q` *(fails: command not found)*