### PR TITLE
Fix YearScratch import paths

### DIFF
--- a/backend/app/services/strategy_engine/strategies/bracket_filling.py
+++ b/backend/app/services/strategy_engine/strategies/bracket_filling.py
@@ -18,7 +18,8 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
-from .base_strategy import BaseStrategy, EngineState, YearScratch
+from .base_strategy import BaseStrategy
+from ..state import EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
 
 # behavioural constants

--- a/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
+++ b/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
@@ -24,7 +24,8 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
-from .base_strategy import BaseStrategy, EngineState, YearScratch
+from .base_strategy import BaseStrategy
+from ..state import EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
 
 ASSUMED_INFLATION = Decimal("0.02")

--- a/backend/app/services/strategy_engine/strategies/early_rrif_conversion.py
+++ b/backend/app/services/strategy_engine/strategies/early_rrif_conversion.py
@@ -28,7 +28,8 @@ from typing import Optional
 from app.data_models.scenario import StrategyCodeEnum
 from app.services.strategy_engine import tax_rules
 
-from .base_strategy import BaseStrategy, EngineState, YearScratch
+from .base_strategy import BaseStrategy
+from ..state import EngineState, YearScratch
 
 # shared constants (kept in sync with other strategies)
 ASSUMED_INFLATION = Decimal("0.02")

--- a/backend/app/services/strategy_engine/strategies/gradual_meltdown.py
+++ b/backend/app/services/strategy_engine/strategies/gradual_meltdown.py
@@ -26,7 +26,8 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum, StrategyParamsInput
-from .base_strategy import BaseStrategy, EngineState, YearScratch
+from .base_strategy import BaseStrategy
+from ..state import EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
 
 ASSUMED_INFLATION = Decimal("0.02")

--- a/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
+++ b/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
@@ -12,7 +12,8 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
-from .base_strategy import BaseStrategy, EngineState, YearScratch
+from .base_strategy import BaseStrategy
+from ..state import EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
 
 ASSUMED_INFLATION = Decimal("0.02")

--- a/backend/app/services/strategy_engine/strategies/lump_sum_withdrawal.py
+++ b/backend/app/services/strategy_engine/strategies/lump_sum_withdrawal.py
@@ -16,7 +16,8 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
-from .base_strategy import BaseStrategy, EngineState, YearScratch
+from .base_strategy import BaseStrategy
+from ..state import EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
 
 ASSUMED_INFLATION = Decimal("0.02")

--- a/backend/app/services/strategy_engine/strategies/spousal_equalization.py
+++ b/backend/app/services/strategy_engine/strategies/spousal_equalization.py
@@ -30,7 +30,8 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
-from .base_strategy import BaseStrategy, EngineState, YearScratch
+from .base_strategy import BaseStrategy
+from ..state import EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
 from app.services.strategy_engine.strategies.gradual_meltdown import (
     TOL,


### PR DESCRIPTION
## Summary
- fix import paths for `YearScratch` now located in `state.py`

## Testing
- `poetry run ruff check .`
- *(tests fail to run: pytest not installed)*