### PR TITLE
Add detailed projection table to strategy explanations

### DIFF
--- a/backend/app/api/v1/endpoints/explain_controller.py
+++ b/backend/app/api/v1/endpoints/explain_controller.py
@@ -22,6 +22,7 @@ async def explain(req: ExplainRequest) -> ExplainApiResponse:
             strategy_code=req.strategy_code,
             summary_metrics=req.summary,
             goal=req.goal,
+            yearly_results=req.yearly_results,
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("LLM explain error: %s", exc)

--- a/backend/app/data_models/explain.py
+++ b/backend/app/data_models/explain.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 from app.data_models.scenario import GoalEnum, ScenarioInput, StrategyCodeEnum
-from app.data_models.results import SummaryMetrics
+from app.data_models.results import SummaryMetrics, YearlyResult
 
 
 class ExplainRequest(BaseModel):
@@ -16,6 +16,7 @@ class ExplainRequest(BaseModel):
     scenario: ScenarioInput
     strategy_code: StrategyCodeEnum
     summary: SummaryMetrics
+    yearly_results: list[YearlyResult] | None = None
     goal: GoalEnum
     request_id: UUID | None = Field(default=None)
 


### PR DESCRIPTION
## Summary
- include yearly results in `ExplainRequest`
- add helper to format projection table in `llm_service`
- extend explanation prompt with detailed projection data

## Testing
- `poetry run pytest` *(fails: Command not found)*