### PR TITLE
Add OpenAI API endpoint setting

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,4 +2,6 @@ DATABASE_URL=postgresql://user:password@localhost:5432/retirement_sessions_db
 TAX_YEARS_FILE=data/tax_years.yml
 SESSION_DATA_TTL_HOURS=24
 # OPENAI_API_KEY=
+# Optional custom endpoint for OpenAI-compatible API
+# OPENAI_API_ENDPOINT_URL=
 # ANTHROPIC_API_KEY=

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -78,6 +78,9 @@ class Settings(BaseSettings):
     # LLM
     # ------------------------------------------------------------------ #
     OPENAI_API_KEY: Optional[str] = Field(default=None, env="OPENAI_API_KEY")
+    OPENAI_API_ENDPOINT_URL: Optional[str] = Field(
+        default=None, env="OPENAI_API_ENDPOINT_URL"
+    )
     OPENAI_MODEL: str = Field("gpt-4o-mini", env="OPENAI_MODEL")
     ANTHROPIC_API_KEY: Optional[str] = Field(default=None, env="ANTHROPIC_API_KEY")
     ANTHROPIC_MODEL: str = Field("claude-3-haiku-20240307", env="ANTHROPIC_MODEL")


### PR DESCRIPTION
## Summary
- support `OPENAI_API_ENDPOINT_URL` in `Settings`
- document it in `.env.example`

## Testing
- `poetry run ruff check .` *(fails: import blocks unsorted)*
- `poetry run pytest -q` *(fails: command not found: pytest)*