### PR TITLE
Update 2025 tax data and add BPA phase out

### DIFF
--- a/backend/app/services/strategy_engine/tax_rules.py
+++ b/backend/app/services/strategy_engine/tax_rules.py
@@ -24,6 +24,9 @@ class TaxBracket(TypedDict):
 class TaxYearData(TypedDict, total=False):
     # --- federal ---
     federal_personal_amount: float
+    federal_personal_amount_min: float
+    federal_personal_amount_phaseout_start: float
+    federal_personal_amount_phaseout_end: float
     federal_age_amount: float
     federal_age_amount_threshold: float
     federal_pension_income_credit_max: float
@@ -151,7 +154,22 @@ def _tax_from_brackets(income: float, brackets: List[TaxBracket]) -> float:
 
 def _federal_credits(income: float, age: int, pension_inc: float, td: TaxYearData) -> float:
     lowest_rate = td["federal_tax_brackets"][0]["rate"]
+
     credit_base = td["federal_personal_amount"]
+    min_pa = td.get("federal_personal_amount_min")
+    start = td.get("federal_personal_amount_phaseout_start")
+    end = td.get("federal_personal_amount_phaseout_end")
+    if (
+        min_pa is not None
+        and start is not None
+        and end is not None
+        and income > start
+    ):
+        if income >= end:
+            credit_base = min_pa
+        else:
+            frac = (income - start) / (end - start)
+            credit_base = credit_base - frac * (credit_base - min_pa)
 
     if age >= 65:
         reduction = max(0.0, (income - td["federal_age_amount_threshold"]) * 0.15)

--- a/backend/data/tax_years.yml
+++ b/backend/data/tax_years.yml
@@ -11,16 +11,19 @@
   # --------------------------------------------------------------------------
   # Federal personal taxes
   # --------------------------------------------------------------------------
-  federal_personal_amount: 15705
+  federal_personal_amount: 15978
+  federal_personal_amount_min: 14156
+  federal_personal_amount_phaseout_start: 173205
+  federal_personal_amount_phaseout_end: 246752
   federal_age_amount: 8396
   federal_age_amount_threshold: 43179
   federal_pension_income_credit_max: 2000
 
-  # 2025 federal brackets (indexed 4.7 % over 2024)
+  # 2025 federal brackets
   federal_tax_brackets:
-    - {upto:  58579, rate: 0.1500}
-    - {upto: 117158, rate: 0.2050}
-    - {upto: 172620, rate: 0.2600}
+    - {upto:  55868, rate: 0.1500}
+    - {upto: 111733, rate: 0.2050}
+    - {upto: 173205, rate: 0.2600}
     - {upto: 246752, rate: 0.2900}
     - {upto: null,   rate: 0.3300}
 
@@ -92,7 +95,7 @@
   # --------------------------------------------------------------------------
   # Ontario personal taxes
   # --------------------------------------------------------------------------
-  ontario_personal_amount: 11865
+  ontario_personal_amount: 12122
   ontario_age_amount: 5750
   ontario_age_amount_threshold: 43179
   ontario_pension_income_credit_max: 1500
@@ -104,9 +107,9 @@
     - {upto: 220000, rate: 0.1216}
     - {upto: null,   rate: 0.1316}
 
-  ontario_surtax_threshold_1: 5554
+  ontario_surtax_threshold_1: 5315
   ontario_surtax_rate_1:      0.20
-  ontario_surtax_threshold_2: 7108
+  ontario_surtax_threshold_2: 6802
   ontario_surtax_rate_2:      0.36
 
 ###############################################################################

--- a/backend/tests/unit/test_tax.py
+++ b/backend/tests/unit/test_tax.py
@@ -1,0 +1,81 @@
+import pytest
+from decimal import Decimal
+from app.services.strategy_engine import tax_rules
+
+TD_2025 = {
+    'federal_personal_amount': 15978,
+    'federal_personal_amount_min': 14156,
+    'federal_personal_amount_phaseout_start': 173205,
+    'federal_personal_amount_phaseout_end': 246752,
+    'federal_age_amount': 8396,
+    'federal_age_amount_threshold': 43179,
+    'federal_pension_income_credit_max': 2000,
+    'federal_tax_brackets': [
+        {'upto': 55868, 'rate': 0.15},
+        {'upto': 111733, 'rate': 0.205},
+        {'upto': 173205, 'rate': 0.26},
+        {'upto': 246752, 'rate': 0.29},
+        {'upto': None, 'rate': 0.33},
+    ],
+    'oas_clawback_threshold': 93454,
+    'oas_clawback_rate': 0.15,
+    'oas_max_benefit_at_65': 8250,
+    'oas_deferral_factor_per_month': 0.006,
+    'cpp_max_benefit_at_65': 17060,
+    'cpp_deferral_factor_per_year': 0.084,
+    'cpp_early_factor_per_year': 0.072,
+    'rrif_table': {},
+    'ontario_personal_amount': 12122,
+    'ontario_age_amount': 5750,
+    'ontario_age_amount_threshold': 43179,
+    'ontario_pension_income_credit_max': 1500,
+    'ontario_tax_brackets': [
+        {'upto': 51446, 'rate': 0.0505},
+        {'upto': 102894, 'rate': 0.0915},
+        {'upto': 150000, 'rate': 0.1116},
+        {'upto': 220000, 'rate': 0.1216},
+        {'upto': None, 'rate': 0.1316},
+    ],
+    'ontario_surtax_threshold_1': 5315,
+    'ontario_surtax_rate_1': 0.20,
+    'ontario_surtax_threshold_2': 6802,
+    'ontario_surtax_rate_2': 0.36,
+}
+
+CASES = {
+    40000: {
+        'federal_tax': Decimal('3603.30'),
+        'provincial_tax': Decimal('1407.84'),
+        'provincial_surtax': Decimal('0.00'),
+        'total_income_tax': Decimal('5011.14'),
+        'oas_clawback': Decimal('0.00'),
+    },
+    95000: {
+        'federal_tax': Decimal('14005.56'),
+        'provincial_tax': Decimal('6102.26'),
+        'provincial_surtax': Decimal('131.21'),
+        'total_income_tax': Decimal('20107.82'),
+        'oas_clawback': Decimal('231.90'),
+    },
+    120000: {
+        'federal_tax': Decimal('19585.24'),
+        'provincial_tax': Decimal('9547.92'),
+        'provincial_surtax': Decimal('945.54'),
+        'total_income_tax': Decimal('29133.17'),
+        'oas_clawback': Decimal('3981.90'),
+    },
+    280000: {
+        'federal_tax': Decimal('65992.32'),
+        'provincial_tax': Decimal('36416.08'),
+        'provincial_surtax': Decimal('8057.70'),
+        'total_income_tax': Decimal('102408.40'),
+        'oas_clawback': Decimal('8250.00'),
+    },
+}
+
+@pytest.mark.parametrize('income', [40000, 95000, 120000, 280000])
+def test_tax_calculations(income):
+    res = tax_rules.calculate_all_taxes(income, age=30, pension_inc=0, td=TD_2025)
+    expected = CASES[income]
+    for key, val in expected.items():
+        assert Decimal(str(res[key])).quantize(Decimal('0.01')) == val


### PR DESCRIPTION
## Summary
- update 2025 constants in `tax_years.yml`
- implement BPA phase-out in tax rules
- add unit tests covering 2025 tax calculations

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*