### PR TITLE
Implement strategy defaults and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,20 @@ npm run dev
 ```
 The app will be served by Vite (typically on `http://localhost:5173`).
 
+## 2025 Tax Assumptions
+
+Tax calculations rely on indexed figures for the 2025 calendar year. Key
+constants include the basic personal amounts, Ontario surtax brackets and the
+Old Age Security (OAS) clawback threshold of `$93\,454`.
+
+## Strategy-Specific Inputs
+
+Each withdrawal method exposes optional parameters. Omitting them triggers
+default behaviours. Notable examples:
+
+- **Bracket Filling** – ceiling defaults to the OAS clawback threshold when not
+  provided.
+- **CPP/OAS Delay** – missing start ages are set to 70.
+- **Interest Offset** – interest rate and loan percent default to 5 % and
+  20 %, respectively.
+

--- a/docs/logic.md
+++ b/docs/logic.md
@@ -1,0 +1,20 @@
+# Calculation Notes
+
+## Basic Personal Amount Phase-out
+
+Both federal and Ontario basic personal amounts decrease once net income
+exceeds their respective age amount thresholds. The reduction formula is:
+
+```
+adjusted_amount = base_amount - max(0, income - threshold) * rate
+```
+
+Where `rate` is 15% federally and 5% provincially. Negative amounts are
+clipped at zero.
+
+## OAS Clawback
+
+Old Age Security benefits are included in taxable income. If net income
+exceeds the clawback threshold, 15% of the excess is added to tax payable up to
+the annual OAS benefit. The engine therefore reports the clawback within the
+`total_income_tax` field.


### PR DESCRIPTION
## Summary
- default strategy parameters like bracket fill ceiling and delayed CPP/OAS start ages
- block unsupported cases (lump sum without amount, spousal strategy without spouse)
- document tax assumptions and strategy inputs
- describe BPA phase-out and OAS clawback in docs

## Testing
- `poetry run ruff check app/data_models/scenario.py`
- `poetry run pytest` *(fails: Command not found)*