### PR TITLE
Implement BPA phaseout in federal credits

### DIFF
--- a/backend/app/services/strategy_engine/tax_rules.py
+++ b/backend/app/services/strategy_engine/tax_rules.py
@@ -153,6 +153,23 @@ def _federal_credits(income: float, age: int, pension_inc: float, td: TaxYearDat
     lowest_rate = td["federal_tax_brackets"][0]["rate"]
     credit_base = td["federal_personal_amount"]
 
+    # Basic personal amount phase‑out for high income earners
+    phase_start = td.get("federal_bpa_phaseout_start")
+    phase_end = td.get("federal_bpa_phaseout_end")
+    personal_min = td.get("federal_personal_amount_low")
+    if (
+        phase_start is not None
+        and phase_end is not None
+        and personal_min is not None
+        and income > phase_start
+    ):
+        if income >= phase_end:
+            credit_base = personal_min
+        else:
+            frac = (income - phase_start) / (phase_end - phase_start)
+            reduction = (td["federal_personal_amount"] - personal_min) * frac
+            credit_base = td["federal_personal_amount"] - reduction
+
     if age >= 65:
         reduction = max(0.0, (income - td["federal_age_amount_threshold"]) * 0.15)
         credit_base += max(0.0, td["federal_age_amount"] - reduction)

--- a/backend/tests/unit/services/strategy_engine/test_tax_rules.py
+++ b/backend/tests/unit/services/strategy_engine/test_tax_rules.py
@@ -1,1 +1,31 @@
-# TODO: Implement Python module
+import unittest
+from app.services.strategy_engine import tax_rules
+
+class FederalCreditsPhaseoutTests(unittest.TestCase):
+    def setUp(self):
+        self.base_td = {
+            "federal_tax_brackets": [{"upto": 50000, "rate": 0.15}],
+            "federal_personal_amount": 15000,
+            "federal_personal_amount_low": 12000,
+            "federal_bpa_phaseout_start": 100000,
+            "federal_bpa_phaseout_end": 150000,
+            "federal_age_amount": 0,
+            "federal_age_amount_threshold": 0,
+            "federal_pension_income_credit_max": 0,
+        }
+
+    def _credits(self, income):
+        return tax_rules._federal_credits(income, 30, 0, self.base_td)
+
+    def test_below_phaseout(self):
+        self.assertAlmostEqual(self._credits(90000), 15000 * 0.15)
+
+    def test_within_phaseout(self):
+        expected_base = 15000 - (15000 - 12000) * (125000 - 100000) / (150000 - 100000)
+        self.assertAlmostEqual(self._credits(125000), expected_base * 0.15)
+
+    def test_above_phaseout(self):
+        self.assertAlmostEqual(self._credits(160000), 12000 * 0.15)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support CRA Basic Personal Amount phase-out in `_federal_credits`
- test personal amount credit across phase-out range

## Testing
- `python -m unittest discover -v`