### PR TITLE
Fix JSON syntax in frontend package

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,9 +14,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
 
-    "react-tooltip": "^5.20.0"
+    "react-tooltip": "^5.20.0",
 
-    "react-hook-form": "^7.45.2"
     "@mui/material": "^5.15.20",
     "@mui/x-data-grid": "^6.19.0",
     "react-hook-form": "^7.48.2",


### PR DESCRIPTION
## Summary
- fix `react-tooltip` comma
- remove duplicate `react-hook-form` entry in `frontend/package.json`

## Testing
- `jq . < frontend/package.json`