### PR TITLE
Fix React DOM types version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ poetry install
 ```bash
 cd frontend
 npm install
+# If you encounter peer dependency errors for `@types/react-dom`,
+# ensure the dev dependency is pinned to a React 18 compatible version:
+#
+#   npm install --save-dev @types/react-dom@18.0.11
 ```
 
 ## Running in Development

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@types/react": "^18.2.0",
-        "@types/react-dom": "^18.2.0",
+        "@types/react-dom": "18.0.11",
         "@vitejs/plugin-react": "^4.4.1",
         "autoprefixer": "^10.4.16",
         "eslint": "^9.25.0",
@@ -1354,12 +1354,11 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
       "dev": true,
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@types/react": "^18.2.0",
-    "@types/react-dom": "^18.2.0",
+    "@types/react-dom": "18.0.11",
     "@vitejs/plugin-react": "^4.4.1",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",


### PR DESCRIPTION
## Summary
- pin @types/react-dom to 18.0.11 to avoid peer dependency errors
- document workaround in README

## Testing
- `poetry run ruff check .` *(fails: Import block is un-sorted, etc.)*
- `poetry run pytest -q` *(fails: Command not found: pytest)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*