### PR TITLE
Fix type import for GridColDef

### DIFF
--- a/frontend/src/components/SimulationForm.tsx
+++ b/frontend/src/components/SimulationForm.tsx
@@ -10,7 +10,8 @@ import {
   Button,
   Typography,
 } from '@mui/material';
-import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import { DataGrid } from '@mui/x-data-grid';
+import type { GridColDef } from '@mui/x-data-grid';
 import { StrategyParamsInput } from '../types/api';
 
 interface FormValues {


### PR DESCRIPTION
## Summary
- fix import of `GridColDef` so it is type-only

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `poetry run ruff check .` *(fails: found 28 errors)*
- `poetry run pytest` *(fails: Command not found: pytest)*