### PR TITLE
Fix import for StrategyParamsInput

### DIFF
--- a/frontend/src/components/SimulationForm.tsx
+++ b/frontend/src/components/SimulationForm.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import type { GridColDef } from '@mui/x-data-grid';
-import { StrategyParamsInput } from '../types/api';
+import type { StrategyParamsInput } from '../types/api';
 
 interface FormValues {
   strategy_params: StrategyParamsInput;


### PR DESCRIPTION
## Summary
- mark `StrategyParamsInput` import as type only to avoid runtime error

## Testing
- `npm test --silent` *(fails: jest not found)*