### PR TITLE
Add strategy selector to frontend

### DIFF
--- a/frontend/src/components/SimulationForm.tsx
+++ b/frontend/src/components/SimulationForm.tsx
@@ -9,10 +9,12 @@ import {
   TextField,
   Button,
   Typography,
+  MenuItem,
 } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import type { GridColDef } from '@mui/x-data-grid';
 import type { StrategyParamsInput } from '../types/api';
+import { strategies } from '../strategies';
 
 interface FormValues {
   strategy_params: StrategyParamsInput;
@@ -117,6 +119,27 @@ export default function SimulationForm() {
 
   return (
     <Box component="form" onSubmit={handleSubmit(onSubmit)} sx={{ p: 2 }}>
+      <Controller
+        name="strategy_code"
+        control={control}
+        render={({ field }) => (
+          <TextField
+            {...field}
+            select
+            label="Strategy"
+            fullWidth
+            margin="normal"
+            error={!!errors.strategy_code}
+            helperText={errors.strategy_code?.message}
+          >
+            {strategies.map((s) => (
+              <MenuItem key={s.code} value={s.code}>
+                {s.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        )}
+      />
       <FormControlLabel
         control={<Checkbox checked={bf} onChange={(_, v) => setBf(v)} />}
         label="Bracket Filling"

--- a/frontend/src/strategies.ts
+++ b/frontend/src/strategies.ts
@@ -1,0 +1,16 @@
+export interface StrategyOption {
+  code: string;
+  label: string;
+}
+
+export const strategies: StrategyOption[] = [
+  { code: 'BF', label: 'Bracket-Filling' },
+  { code: 'GM', label: 'Gradual Meltdown' },
+  { code: 'E65', label: 'Early RRIF @65' },
+  { code: 'CD', label: 'CPP/OAS Delay' },
+  { code: 'SEQ', label: 'Spousal Equalisation' },
+  { code: 'IO', label: 'Interest-Offset Loan' },
+  { code: 'LS', label: 'Lump-Sum Withdrawal' },
+  { code: 'EBX', label: 'Empty-by-X' },
+  { code: 'MIN', label: 'RRIF Minimum Only' },
+];


### PR DESCRIPTION
## Summary
- expose dropdown to choose strategy code in `SimulationForm`
- list available strategies in new shared `strategies.ts`

## Testing
- `poetry run ruff check .` *(fails: found 28 errors)*
- `poetry run pytest` *(fails: command not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*