### PR TITLE
Expose strategy metadata and update simulator UI

### DIFF
--- a/frontend/src/components/SimulationForm.tsx
+++ b/frontend/src/components/SimulationForm.tsx
@@ -6,21 +6,25 @@ import {
   Box,
   Checkbox,
   FormControlLabel,
+  FormGroup,
+  RadioGroup,
+  Radio,
   TextField,
   Button,
   Typography,
+  Select,
+  MenuItem,
 } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import type { GridColDef } from '@mui/x-data-grid';
 import type { StrategyParamsInput } from '../types/api';
+import { ALL_STRATEGIES, StrategyCodeEnum } from '../strategies';
 
 interface FormValues {
   strategy_params: StrategyParamsInput;
-  strategy_code: string;
 }
 
 const schema = yup.object({
-  strategy_code: yup.string().required(),
   strategy_params: yup.object({
     bracket_fill_ceiling: yup
       .number()
@@ -62,11 +66,22 @@ const schema = yup.object({
 });
 
 export default function SimulationForm() {
-  const [bf, setBf] = useState(false);
-  const [ls, setLs] = useState(false);
-  const [ebx, setEbx] = useState(false);
-  const [delay, setDelay] = useState(false);
-  const [interest, setInterest] = useState(false);
+  const [mode, setMode] = useState<'simulate' | 'compare'>('simulate');
+  const [selectedStrategy, setSelectedStrategy] = useState<StrategyCodeEnum>('GM');
+  const [compareSelection, setCompareSelection] = useState<StrategyCodeEnum[]>([]);
+  const [toggles, setToggles] = useState<Record<StrategyCodeEnum, boolean>>(
+    Object.fromEntries(ALL_STRATEGIES.map((s) => [s.code, false])) as Record<StrategyCodeEnum, boolean>
+  );
+
+  const handleToggle = (code: StrategyCodeEnum, value: boolean) => {
+    setToggles((prev) => ({ ...prev, [code]: value }));
+  };
+
+  const handleCompareSelect = (code: StrategyCodeEnum, value: boolean) => {
+    setCompareSelection((prev) =>
+      value ? [...prev, code] : prev.filter((c) => c !== code)
+    );
+  };
 
   const {
     control,
@@ -75,23 +90,34 @@ export default function SimulationForm() {
   } = useForm<FormValues>({
     defaultValues: {
       strategy_params: {},
-      strategy_code: 'GM',
     },
-    context: { bf, ls, ebx, delay, interest },
+    context: {
+      bf: toggles.BF,
+      ls: toggles.LS,
+      ebx: toggles.EBX,
+      delay: toggles.CD,
+      interest: toggles.IO,
+    },
     resolver: yupResolver(schema),
   });
 
   const [rows, setRows] = useState([]);
 
   const onSubmit = async (data: FormValues) => {
-    const body = {
+    const body: any = {
       scenario: {
         params: data.strategy_params,
       },
-      strategy_code: data.strategy_code,
     };
+    let url = '/api/v1/simulate';
+    if (mode === 'compare') {
+      url = '/api/v1/compare';
+      body.strategies = compareSelection;
+    } else {
+      body.strategy_code = selectedStrategy;
+    }
     try {
-      const resp = await fetch('/api/v1/simulate', {
+      const resp = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -115,171 +141,219 @@ export default function SimulationForm() {
     { field: 'net_income', headerName: 'Net Income', width: 120 },
   ];
 
+  const renderParamFields = (code: StrategyCodeEnum) => {
+    switch (code) {
+      case 'BF':
+        return (
+          <Controller
+            name="strategy_params.bracket_fill_ceiling"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Income ceiling ($)"
+                error={!!errors.strategy_params?.bracket_fill_ceiling}
+                helperText={errors.strategy_params?.bracket_fill_ceiling?.message}
+                type="number"
+                fullWidth
+                margin="normal"
+              />
+            )}
+          />
+        );
+      case 'LS':
+        return (
+          <Box>
+            <Controller
+              name="strategy_params.lump_sum_amount"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  label="Lump-Sum ($)"
+                  error={!!errors.strategy_params?.lump_sum_amount}
+                  helperText={errors.strategy_params?.lump_sum_amount?.message}
+                  type="number"
+                  fullWidth
+                  margin="normal"
+                />
+              )}
+            />
+            <Controller
+              name="strategy_params.lump_sum_year_offset"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  label="Year Offset"
+                  error={!!errors.strategy_params?.lump_sum_year_offset}
+                  helperText={errors.strategy_params?.lump_sum_year_offset?.message}
+                  type="number"
+                  fullWidth
+                  margin="normal"
+                />
+              )}
+            />
+          </Box>
+        );
+      case 'EBX':
+        return (
+          <Controller
+            name="strategy_params.target_depletion_age"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Deplete RRIF by age"
+                error={!!errors.strategy_params?.target_depletion_age}
+                helperText={errors.strategy_params?.target_depletion_age?.message}
+                type="number"
+                fullWidth
+                margin="normal"
+              />
+            )}
+          />
+        );
+      case 'CD':
+        return (
+          <Box>
+            <Controller
+              name="strategy_params.cpp_start_age"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  label="CPP start age"
+                  error={!!errors.strategy_params?.cpp_start_age}
+                  helperText={errors.strategy_params?.cpp_start_age?.message}
+                  type="number"
+                  fullWidth
+                  margin="normal"
+                />
+              )}
+            />
+            <Controller
+              name="strategy_params.oas_start_age"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  label="OAS start age"
+                  error={!!errors.strategy_params?.oas_start_age}
+                  helperText={errors.strategy_params?.oas_start_age?.message}
+                  type="number"
+                  fullWidth
+                  margin="normal"
+                />
+              )}
+            />
+          </Box>
+        );
+      case 'IO':
+        return (
+          <Box>
+            <Controller
+              name="strategy_params.interest_rate"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  label="Loan interest rate %"
+                  error={!!errors.strategy_params?.interest_rate}
+                  helperText={errors.strategy_params?.interest_rate?.message}
+                  type="number"
+                  fullWidth
+                  margin="normal"
+                />
+              )}
+            />
+            <Controller
+              name="strategy_params.loan_pct_rrif"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  label="Loan % of RRIF (0-100)"
+                  error={!!errors.strategy_params?.loan_pct_rrif}
+                  helperText={errors.strategy_params?.loan_pct_rrif?.message}
+                  type="number"
+                  fullWidth
+                  margin="normal"
+                />
+              )}
+            />
+          </Box>
+        );
+      default:
+        return null;
+    }
+  };
+
   return (
     <Box component="form" onSubmit={handleSubmit(onSubmit)} sx={{ p: 2 }}>
       <FormControlLabel
-        control={<Checkbox checked={bf} onChange={(_, v) => setBf(v)} />}
-        label="Bracket Filling"
+        control={
+          <Checkbox
+            checked={mode === 'compare'}
+            onChange={(_, v) => setMode(v ? 'compare' : 'simulate')}
+          />
+        }
+        label="Compare multiple strategies"
       />
-      {bf && (
-        <Controller
-          name="strategy_params.bracket_fill_ceiling"
-          control={control}
-          render={({ field }) => (
-            <TextField
-              {...field}
-              label="Income ceiling ($)"
-              error={!!errors.strategy_params?.bracket_fill_ceiling}
-              helperText={errors.strategy_params?.bracket_fill_ceiling?.message}
-              type="number"
-              fullWidth
-              margin="normal"
+
+      {mode === 'simulate' ? (
+        <TextField
+          select
+          label="Strategy"
+          value={selectedStrategy}
+          onChange={(e) =>
+            setSelectedStrategy(e.target.value as StrategyCodeEnum)
+          }
+          fullWidth
+          margin="normal"
+        >
+          {ALL_STRATEGIES.map((s) => (
+            <MenuItem key={s.code} value={s.code}>
+              {s.label}
+            </MenuItem>
+          ))}
+        </TextField>
+      ) : (
+        <FormGroup>
+          {ALL_STRATEGIES.map((s) => (
+            <FormControlLabel
+              key={s.code}
+              control={
+                <Checkbox
+                  checked={compareSelection.includes(s.code)}
+                  onChange={(_, v) => handleCompareSelect(s.code, v)}
+                />
+              }
+              label={s.label}
             />
-          )}
-        />
+          ))}
+        </FormGroup>
       )}
 
-      <FormControlLabel
-        control={<Checkbox checked={ls} onChange={(_, v) => setLs(v)} />}
-        label="Lump-Sum"
-      />
-      {ls && (
-        <Box>
-          <Controller
-            name="strategy_params.lump_sum_amount"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                label="Lump-Sum ($)"
-                error={!!errors.strategy_params?.lump_sum_amount}
-                helperText={errors.strategy_params?.lump_sum_amount?.message}
-                type="number"
-                fullWidth
-                margin="normal"
+      {ALL_STRATEGIES.map((s) => (
+        <Box key={`params-${s.code}`}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={toggles[s.code]}
+                onChange={(_, v) => handleToggle(s.code, v)}
               />
-            )}
+            }
+            label={s.label}
           />
-          <Controller
-            name="strategy_params.lump_sum_year_offset"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                label="Year Offset"
-                error={!!errors.strategy_params?.lump_sum_year_offset}
-                helperText={errors.strategy_params?.lump_sum_year_offset?.message}
-                type="number"
-                fullWidth
-                margin="normal"
-              />
-            )}
-          />
+          {toggles[s.code] && renderParamFields(s.code)}
         </Box>
-      )}
-
-      <FormControlLabel
-        control={<Checkbox checked={ebx} onChange={(_, v) => setEbx(v)} />}
-        label="Empty-by-X"
-      />
-      {ebx && (
-        <Controller
-          name="strategy_params.target_depletion_age"
-          control={control}
-          render={({ field }) => (
-            <TextField
-              {...field}
-              label="Deplete RRIF by age"
-              error={!!errors.strategy_params?.target_depletion_age}
-              helperText={errors.strategy_params?.target_depletion_age?.message}
-              type="number"
-              fullWidth
-              margin="normal"
-            />
-          )}
-        />
-      )}
-
-      <FormControlLabel
-        control={<Checkbox checked={delay} onChange={(_, v) => setDelay(v)} />}
-        label="Delay CPP/OAS"
-      />
-      {delay && (
-        <Box>
-          <Controller
-            name="strategy_params.cpp_start_age"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                label="CPP start age"
-                error={!!errors.strategy_params?.cpp_start_age}
-                helperText={errors.strategy_params?.cpp_start_age?.message}
-                type="number"
-                fullWidth
-                margin="normal"
-              />
-            )}
-          />
-          <Controller
-            name="strategy_params.oas_start_age"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                label="OAS start age"
-                error={!!errors.strategy_params?.oas_start_age}
-                helperText={errors.strategy_params?.oas_start_age?.message}
-                type="number"
-                fullWidth
-                margin="normal"
-              />
-            )}
-          />
-        </Box>
-      )}
-
-      <FormControlLabel
-        control={<Checkbox checked={interest} onChange={(_, v) => setInterest(v)} />}
-        label="Interest Offset"
-      />
-      {interest && (
-        <Box>
-          <Controller
-            name="strategy_params.interest_rate"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                label="Loan interest rate %"
-                error={!!errors.strategy_params?.interest_rate}
-                helperText={errors.strategy_params?.interest_rate?.message}
-                type="number"
-                fullWidth
-                margin="normal"
-              />
-            )}
-          />
-          <Controller
-            name="strategy_params.loan_pct_rrif"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                label="Loan % of RRIF (0-100)"
-                error={!!errors.strategy_params?.loan_pct_rrif}
-                helperText={errors.strategy_params?.loan_pct_rrif?.message}
-                type="number"
-                fullWidth
-                margin="normal"
-              />
-            )}
-          />
-        </Box>
-      )}
+      ))}
 
       <Box mt={2}>
-        <Button type="submit" variant="contained">Simulate</Button>
+        <Button type="submit" variant="contained">
+          {mode === 'compare' ? 'Compare' : 'Simulate'}
+        </Button>
       </Box>
 
       {rows.length > 0 && (

--- a/frontend/src/strategies.ts
+++ b/frontend/src/strategies.ts
@@ -1,0 +1,90 @@
+export type GoalEnum =
+  | 'minimize_tax'
+  | 'maximize_spending'
+  | 'preserve_estate'
+  | 'simplify';
+
+export type StrategyCodeEnum =
+  | 'BF'
+  | 'GM'
+  | 'E65'
+  | 'CD'
+  | 'SEQ'
+  | 'IO'
+  | 'LS'
+  | 'EBX'
+  | 'MIN';
+
+export interface StrategyMeta {
+  code: StrategyCodeEnum;
+  label: string;
+  blurb: string;
+  default_complexity: number;
+  typical_goals: GoalEnum[];
+}
+
+export const ALL_STRATEGIES: StrategyMeta[] = [
+  {
+    code: 'BF',
+    label: 'Bracket-Filling',
+    blurb: 'Cap taxable income at a chosen ceiling.',
+    default_complexity: 2,
+    typical_goals: ['minimize_tax', 'simplify'],
+  },
+  {
+    code: 'GM',
+    label: 'Gradual Meltdown',
+    blurb: 'Withdraw just enough each year to meet spending.',
+    default_complexity: 1,
+    typical_goals: ['maximize_spending', 'simplify'],
+  },
+  {
+    code: 'E65',
+    label: 'Early RRIF @65',
+    blurb: 'Convert RRSP early for pension credits & income splitting.',
+    default_complexity: 2,
+    typical_goals: ['minimize_tax'],
+  },
+  {
+    code: 'CD',
+    label: 'CPP/OAS Delay',
+    blurb: 'Delay government pensions; bridge spending with RRIF.',
+    default_complexity: 3,
+    typical_goals: ['maximize_spending'],
+  },
+  {
+    code: 'SEQ',
+    label: 'Spousal Equalisation',
+    blurb: 'Even out taxable income between spouses.',
+    default_complexity: 3,
+    typical_goals: ['minimize_tax'],
+  },
+  {
+    code: 'IO',
+    label: 'Interest-Offset Loan',
+    blurb: 'Use deductible interest to offset RRIF tax.',
+    default_complexity: 5,
+    typical_goals: ['minimize_tax'],
+  },
+  {
+    code: 'LS',
+    label: 'Lump-Sum Withdrawal',
+    blurb: 'One-time large withdrawal in a specified year.',
+    default_complexity: 2,
+    typical_goals: ['simplify'],
+  },
+  {
+    code: 'EBX',
+    label: 'Empty-by-X',
+    blurb: 'Systematically deplete RRIF by a target age.',
+    default_complexity: 2,
+    typical_goals: ['preserve_estate', 'minimize_tax'],
+  },
+  {
+    code: 'MIN',
+    label: 'RRIF Minimum Only',
+    blurb: 'Withdraw only the CRA-mandated minimum each year.',
+    default_complexity: 1,
+    typical_goals: ['simplify', 'preserve_estate'],
+  },
+];


### PR DESCRIPTION
## Summary
- add strategy metadata list to the frontend
- revamp SimulationForm to use the shared strategy list
- allow selecting a single strategy or multiple strategies for compare

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `poetry run ruff check .` *(fails: found 28 errors)*
- `poetry run pytest` *(fails: pytest not found)*