### PR TITLE
Add goal selector to simulation form

### DIFF
--- a/frontend/src/components/SimulationForm.tsx
+++ b/frontend/src/components/SimulationForm.tsx
@@ -9,17 +9,30 @@ import {
   TextField,
   Button,
   Typography,
+  MenuItem,
 } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import type { GridColDef } from '@mui/x-data-grid';
-import type { StrategyParamsInput } from '../types/api';
+import type { StrategyParamsInput, GoalEnum } from '../types/api';
+
+const GOALS: GoalEnum[] = [
+  'minimize_tax',
+  'maximize_spending',
+  'preserve_estate',
+  'simplify',
+];
 
 interface FormValues {
   strategy_params: StrategyParamsInput;
   strategy_code: string;
+  goal: GoalEnum;
 }
 
 const schema = yup.object({
+  goal: yup
+    .string()
+    .oneOf(GOALS)
+    .required(),
   strategy_code: yup.string().required(),
   strategy_params: yup.object({
     bracket_fill_ceiling: yup
@@ -76,6 +89,7 @@ export default function SimulationForm() {
     defaultValues: {
       strategy_params: {},
       strategy_code: 'GM',
+      goal: 'maximize_spending',
     },
     context: { bf, ls, ebx, delay, interest },
     resolver: yupResolver(schema),
@@ -86,6 +100,7 @@ export default function SimulationForm() {
   const onSubmit = async (data: FormValues) => {
     const body = {
       scenario: {
+        goal: data.goal,
         params: data.strategy_params,
       },
       strategy_code: data.strategy_code,
@@ -117,6 +132,27 @@ export default function SimulationForm() {
 
   return (
     <Box component="form" onSubmit={handleSubmit(onSubmit)} sx={{ p: 2 }}>
+      <Controller
+        name="goal"
+        control={control}
+        render={({ field }) => (
+          <TextField
+            {...field}
+            select
+            label="Goal"
+            error={!!errors.goal}
+            helperText={errors.goal?.message}
+            fullWidth
+            margin="normal"
+          >
+            {GOALS.map((g) => (
+              <MenuItem key={g} value={g}>
+                {g.replace('_', ' ')}
+              </MenuItem>
+            ))}
+          </TextField>
+        )}
+      />
       <FormControlLabel
         control={<Checkbox checked={bf} onChange={(_, v) => setBf(v)} />}
         label="Bracket Filling"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -10,6 +10,12 @@ export interface StrategyParamsInput {
   loan_amount_as_pct_of_rrif?: number;
 }
 
+export type GoalEnum =
+  | 'minimize_tax'
+  | 'maximize_spending'
+  | 'preserve_estate'
+  | 'simplify';
+
 export interface ScenarioInput {
   age: number;
   rrsp_balance: number;
@@ -22,7 +28,7 @@ export interface ScenarioInput {
   stddev_return_pct: number;
   life_expectancy_years: number;
   province: string;
-  goal: string;
+  goal: GoalEnum;
   spouse?: {
     age: number;
     rrsp_balance: number;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -19,3 +19,9 @@ export interface StrategyParamsInput {
   loan_pct_rrif?: number;
   spouse?: SpouseInfo;
 }
+
+export type GoalEnum =
+  | 'minimize_tax'
+  | 'maximize_spending'
+  | 'preserve_estate'
+  | 'simplify';


### PR DESCRIPTION
## Summary
- support choosing goal in simulation form
- track selected goal in request body
- declare GoalEnum types for API and Scenario

## Testing
- `poetry run ruff check .` *(fails: import sorting issues)*
- `poetry run pytest` *(fails: Command not found)*
- `npm run lint` *(fails: missing ESLint deps)*
- `npm test --if-present` *(fails: jest not found)*