### PR TITLE
Expose strategy list and recommendations

### DIFF
--- a/backend/tests/integration/api/v1/test_strategies.py
+++ b/backend/tests/integration/api/v1/test_strategies.py
@@ -1,0 +1,19 @@
+import pytest
+
+from app.data_models.scenario import GoalEnum
+
+@pytest.mark.asyncio
+async def test_strategies_basic(client):
+    resp = await client.get('/api/v1/strategies')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'strategies' in data
+    assert isinstance(data['strategies'], list)
+    assert data['recommended'] == []
+
+@pytest.mark.asyncio
+async def test_strategies_with_goal(client):
+    resp = await client.get(f'/api/v1/strategies?goal={GoalEnum.MAXIMIZE_SPENDING.value}')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data['recommended']) == {'CD', 'GM', 'LS'}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -19,3 +19,16 @@ export interface StrategyParamsInput {
   loan_pct_rrif?: number;
   spouse?: SpouseInfo;
 }
+
+export interface StrategyMeta {
+  code: string;
+  label: string;
+  blurb: string;
+  default_complexity: number;
+  typical_goals: string[];
+}
+
+export interface StrategiesResponse {
+  strategies: StrategyMeta[];
+  recommended: string[];
+}


### PR DESCRIPTION
## Summary
- add `/strategies` endpoint that returns `ALL_STRATEGIES` and goal-based recommendations
- create integration tests for the new endpoint
- extend frontend API types
- fetch recommended strategies on goal change and allow auto-compare

## Testing
- `poetry run ruff check .` *(fails: import sorting and unused imports)*
- `poetry run pytest` *(fails: command not found)*
- `npm run lint` *(fails: missing dependencies)*
- `npm test` *(fails: jest not found)*