### PR TITLE
Ensure strategies self-register

### DIFF
--- a/backend/app/services/strategy_engine/engine.py
+++ b/backend/app/services/strategy_engine/engine.py
@@ -37,6 +37,12 @@ def register(code: str):
 
 
 # ------------------------------------------------------------------
+# Load all strategy modules so decorators run on import
+# ------------------------------------------------------------------
+from . import strategies as _loaded_strategies  # noqa: F401
+
+
+# ------------------------------------------------------------------
 # Existing helper for single-strategy execution (unchanged)
 # ------------------------------------------------------------------
 

--- a/backend/app/services/strategy_engine/strategies/__init__.py
+++ b/backend/app/services/strategy_engine/strategies/__init__.py
@@ -1,1 +1,23 @@
-"""Individual withdrawal strategies."""
+"""Individual withdrawal strategies.
+
+Importing this package registers all strategy classes via the ``register``
+decorator in :mod:`app.services.strategy_engine.engine`.
+"""
+
+from . import bracket_filling  # noqa: F401
+from . import delay_cpp_oas  # noqa: F401
+from . import early_rrif_conversion  # noqa: F401
+from . import gradual_meltdown  # noqa: F401
+from . import interest_offset_loan  # noqa: F401
+from . import lump_sum_withdrawal  # noqa: F401
+from . import spousal_equalization  # noqa: F401
+
+__all__ = [
+    "bracket_filling",
+    "delay_cpp_oas",
+    "early_rrif_conversion",
+    "gradual_meltdown",
+    "interest_offset_loan",
+    "lump_sum_withdrawal",
+    "spousal_equalization",
+]

--- a/backend/app/services/strategy_engine/strategies/bracket_filling.py
+++ b/backend/app/services/strategy_engine/strategies/bracket_filling.py
@@ -18,6 +18,7 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
+from ..engine import register
 from .base_strategy import BaseStrategy, EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
 
@@ -26,6 +27,7 @@ ASSUMED_INFLATION = Decimal("0.02")
 TAXABLE_PORTION_NONREG_GROWTH = Decimal("0.40")
 
 
+@register(StrategyCodeEnum.BF)
 class BracketFillingStrategy(BaseStrategy):
     code = StrategyCodeEnum.BF
     complexity = 2

--- a/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
+++ b/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
@@ -24,6 +24,7 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
+from ..engine import register
 from .base_strategy import BaseStrategy, EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
 
@@ -33,6 +34,7 @@ MAX_ITER = 20
 TOL = Decimal("1")
 
 
+@register(StrategyCodeEnum.CD)
 class DelayCppOasStrategy(BaseStrategy):
     code = StrategyCodeEnum.CD
     display_name = "Delay CPP / OAS (RRSP Bridge)"

--- a/backend/app/services/strategy_engine/strategies/early_rrif_conversion.py
+++ b/backend/app/services/strategy_engine/strategies/early_rrif_conversion.py
@@ -26,6 +26,7 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
+from ..engine import register
 from app.services.strategy_engine import tax_rules
 
 from .base_strategy import BaseStrategy, EngineState, YearScratch
@@ -35,6 +36,7 @@ ASSUMED_INFLATION = Decimal("0.02")
 TAXABLE_PORTION_NONREG_GROWTH = Decimal("0.40")
 
 
+@register(StrategyCodeEnum.E65)
 class EarlyRRIFConversionStrategy(BaseStrategy):
     code = StrategyCodeEnum.E65
     display_name = "Early RRIF Conversion @65"

--- a/backend/app/services/strategy_engine/strategies/gradual_meltdown.py
+++ b/backend/app/services/strategy_engine/strategies/gradual_meltdown.py
@@ -26,6 +26,7 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum, StrategyParamsInput
+from ..engine import register
 from .base_strategy import BaseStrategy, EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
 
@@ -35,6 +36,7 @@ MAX_ITER = 20
 TOL = Decimal("1")  # $1 tolerance for cash shortfall
 
 
+@register(StrategyCodeEnum.GM)
 class GradualMeltdownStrategy(BaseStrategy):
     code = StrategyCodeEnum.GM
     complexity = 1
@@ -215,6 +217,7 @@ class GradualMeltdownStrategy(BaseStrategy):
         return high  # fallback
 
 
+@register(StrategyCodeEnum.EBX)
 class EmptyByXStrategy(GradualMeltdownStrategy):
     """Variant requiring target_depletion_age parameter."""
 

--- a/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
+++ b/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
@@ -12,6 +12,7 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
+from ..engine import register
 from .base_strategy import BaseStrategy, EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
 
@@ -21,6 +22,7 @@ MAX_ITER = 20
 TOL = Decimal("1")            # $1 cash‑flow tolerance
 
 
+@register(StrategyCodeEnum.IO)
 class InterestOffsetStrategy(BaseStrategy):
     """Alias kept for backward compatibility."""
     code = StrategyCodeEnum.IO

--- a/backend/app/services/strategy_engine/strategies/lump_sum_withdrawal.py
+++ b/backend/app/services/strategy_engine/strategies/lump_sum_withdrawal.py
@@ -16,6 +16,7 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
+from ..engine import register
 from .base_strategy import BaseStrategy, EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
 
@@ -25,6 +26,7 @@ MAX_ITER = 20
 TOL = Decimal("1")  # $1 tolerance on cash shortfall
 
 
+@register(StrategyCodeEnum.LS)
 class LumpSumWithdrawalStrategy(BaseStrategy):
     code = StrategyCodeEnum.LS
     display_name = "Lump‑Sum Withdrawal"

--- a/backend/app/services/strategy_engine/strategies/spousal_equalization.py
+++ b/backend/app/services/strategy_engine/strategies/spousal_equalization.py
@@ -30,6 +30,7 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
+from ..engine import register
 from .base_strategy import BaseStrategy, EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
 from app.services.strategy_engine.strategies.gradual_meltdown import (
@@ -37,8 +38,9 @@ from app.services.strategy_engine.strategies.gradual_meltdown import (
     MAX_ITER,
     ASSUMED_INFLATION,
     TAXABLE_PORTION_NONREG_GROWTH,
-)
+) 
 
+@register(StrategyCodeEnum.SEQ)
 class SpousalEqualizationStrategy(BaseStrategy):
     code = StrategyCodeEnum.SEQ
     complexity = 3


### PR DESCRIPTION
## Summary
- register each strategy class with the `register` decorator
- import all strategy modules on package import
- auto-load strategies when `engine` is imported

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*