### PR TITLE
Improve bracket-fill default and tests

### DIFF
--- a/backend/app/data_models/scenario.py
+++ b/backend/app/data_models/scenario.py
@@ -243,7 +243,13 @@ class SimulateRequest(BaseModel):
 
         if code == StrategyCodeEnum.BF:
             if params.bracket_fill_ceiling is None:
-                params.bracket_fill_ceiling = td["oas_clawback_threshold"]
+                if "oas_clawback_threshold" in td:
+                    params.bracket_fill_ceiling = td["oas_clawback_threshold"]
+                else:
+                    raise ValueError(
+                        "Tax data missing 'oas_clawback_threshold'; cannot "
+                        "default bracket_fill_ceiling"
+                    )
 
         if code == StrategyCodeEnum.LS:
             if params.lump_sum_amount is None:

--- a/backend/tests/unit/test_scenario_defaults.py
+++ b/backend/tests/unit/test_scenario_defaults.py
@@ -1,0 +1,31 @@
+import importlib
+import pytest
+
+from app.data_models.scenario import ScenarioInput, SimulateRequest, StrategyCodeEnum
+from app.utils import year_data_loader
+
+EXAMPLE = ScenarioInput.Config.json_schema_extra["example"].copy()
+EXAMPLE.pop("params", None)
+
+
+def test_bf_defaults_to_oas_threshold(monkeypatch):
+    data = {"oas_clawback_threshold": 88000}
+    monkeypatch.setattr(year_data_loader, "load_tax_year_data", lambda y, p="ON": data)
+    scenario = ScenarioInput(**EXAMPLE)
+    SimulateRequest(scenario=scenario, strategy_code=StrategyCodeEnum.BF)
+    assert scenario.strategy_params_override.bracket_fill_ceiling == data["oas_clawback_threshold"]
+
+
+def test_bf_missing_oas_threshold_raises(monkeypatch):
+    monkeypatch.setattr(year_data_loader, "load_tax_year_data", lambda y, p="ON": {})
+    scenario = ScenarioInput(**EXAMPLE)
+    with pytest.raises(ValueError, match="oas_clawback_threshold"):
+        SimulateRequest(scenario=scenario, strategy_code=StrategyCodeEnum.BF)
+
+
+def test_load_tax_year_data_parses_yaml(monkeypatch):
+    import app.utils.year_data_loader as ydl
+    ydl = importlib.reload(ydl)
+    data = ydl.load_tax_year_data(2025, "ON")
+    assert data["federal_personal_amount"] == 15978
+


### PR DESCRIPTION
## Summary
- validate presence of `oas_clawback_threshold` when applying BF defaults
- add new unit tests for scenario defaults and YAML loader

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*