### PR TITLE
Ensure strategies auto-register

### DIFF
--- a/backend/app/services/strategy_engine/strategies/bracket_filling.py
+++ b/backend/app/services/strategy_engine/strategies/bracket_filling.py
@@ -18,14 +18,17 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
-from .base_strategy import BaseStrategy, EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
+from app.services.strategy_engine.engine import register
+
+from .base_strategy import BaseStrategy, EngineState, YearScratch
 
 # behavioural constants
 ASSUMED_INFLATION = Decimal("0.02")
 TAXABLE_PORTION_NONREG_GROWTH = Decimal("0.40")
 
 
+@register(StrategyCodeEnum.BF.value)
 class BracketFillingStrategy(BaseStrategy):
     code = StrategyCodeEnum.BF
     complexity = 2

--- a/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
+++ b/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
@@ -24,8 +24,10 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
-from .base_strategy import BaseStrategy, EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
+from app.services.strategy_engine.engine import register
+
+from .base_strategy import BaseStrategy, EngineState, YearScratch
 
 ASSUMED_INFLATION = Decimal("0.02")
 TAXABLE_PORTION_NONREG_GROWTH = Decimal("0.40")
@@ -33,6 +35,7 @@ MAX_ITER = 20
 TOL = Decimal("1")
 
 
+@register(StrategyCodeEnum.CD.value)
 class DelayCppOasStrategy(BaseStrategy):
     code = StrategyCodeEnum.CD
     display_name = "Delay CPP / OAS (RRSP Bridge)"

--- a/backend/app/services/strategy_engine/strategies/early_rrif_conversion.py
+++ b/backend/app/services/strategy_engine/strategies/early_rrif_conversion.py
@@ -27,6 +27,7 @@ from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
 from app.services.strategy_engine import tax_rules
+from app.services.strategy_engine.engine import register
 
 from .base_strategy import BaseStrategy, EngineState, YearScratch
 
@@ -35,6 +36,7 @@ ASSUMED_INFLATION = Decimal("0.02")
 TAXABLE_PORTION_NONREG_GROWTH = Decimal("0.40")
 
 
+@register(StrategyCodeEnum.E65.value)
 class EarlyRRIFConversionStrategy(BaseStrategy):
     code = StrategyCodeEnum.E65
     display_name = "Early RRIF Conversion @65"

--- a/backend/app/services/strategy_engine/strategies/gradual_meltdown.py
+++ b/backend/app/services/strategy_engine/strategies/gradual_meltdown.py
@@ -25,9 +25,11 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Optional
 
-from app.data_models.scenario import StrategyCodeEnum, StrategyParamsInput
-from .base_strategy import BaseStrategy, EngineState, YearScratch
+from app.data_models.scenario import StrategyCodeEnum
 from app.services.strategy_engine import tax_rules
+from app.services.strategy_engine.engine import register
+
+from .base_strategy import BaseStrategy, EngineState, YearScratch
 
 ASSUMED_INFLATION = Decimal("0.02")
 TAXABLE_PORTION_NONREG_GROWTH = Decimal("0.40")
@@ -35,6 +37,7 @@ MAX_ITER = 20
 TOL = Decimal("1")  # $1 tolerance for cash shortfall
 
 
+@register(StrategyCodeEnum.GM.value)
 class GradualMeltdownStrategy(BaseStrategy):
     code = StrategyCodeEnum.GM
     complexity = 1
@@ -215,6 +218,7 @@ class GradualMeltdownStrategy(BaseStrategy):
         return high  # fallback
 
 
+@register(StrategyCodeEnum.EBX.value)
 class EmptyByXStrategy(GradualMeltdownStrategy):
     """Variant requiring target_depletion_age parameter."""
 

--- a/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
+++ b/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
@@ -12,8 +12,10 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
-from .base_strategy import BaseStrategy, EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
+from app.services.strategy_engine.engine import register
+
+from .base_strategy import BaseStrategy, EngineState, YearScratch
 
 ASSUMED_INFLATION = Decimal("0.02")
 TAXABLE_PORTION_NONREG_GROWTH = Decimal("0.40")
@@ -21,6 +23,7 @@ MAX_ITER = 20
 TOL = Decimal("1")            # $1 cash‑flow tolerance
 
 
+@register(StrategyCodeEnum.IO.value)
 class InterestOffsetStrategy(BaseStrategy):
     """Alias kept for backward compatibility."""
     code = StrategyCodeEnum.IO

--- a/backend/app/services/strategy_engine/strategies/lump_sum_withdrawal.py
+++ b/backend/app/services/strategy_engine/strategies/lump_sum_withdrawal.py
@@ -16,8 +16,10 @@ from decimal import Decimal
 from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
-from .base_strategy import BaseStrategy, EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
+from app.services.strategy_engine.engine import register
+
+from .base_strategy import BaseStrategy, EngineState, YearScratch
 
 ASSUMED_INFLATION = Decimal("0.02")
 TAXABLE_PORTION_NONREG_GROWTH = Decimal("0.40")
@@ -25,6 +27,7 @@ MAX_ITER = 20
 TOL = Decimal("1")  # $1 tolerance on cash shortfall
 
 
+@register(StrategyCodeEnum.LS.value)
 class LumpSumWithdrawalStrategy(BaseStrategy):
     code = StrategyCodeEnum.LS
     display_name = "Lump‑Sum Withdrawal"

--- a/backend/app/services/strategy_engine/strategies/spousal_equalization.py
+++ b/backend/app/services/strategy_engine/strategies/spousal_equalization.py
@@ -15,7 +15,7 @@ Rules & simplifications
 * Household has ONE RRIF balance (primary).  We notionally “attribute”
   half the withdrawal to each spouse for tax purposes.
 * Other taxable income:
-    – Primary: non‑reg taxable growth.  
+    – Primary: non‑reg taxable growth.
     – Spouse : `spouse.other_income`.
 * CPP/OAS amounts taken at age 65 (no deferral parameters here).
 * Surplus after‑tax cash is reinvested in the non‑registered account.
@@ -27,18 +27,21 @@ Complexity score = 3 (requires dual tax calculations each year).
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Optional
 
 from app.data_models.scenario import StrategyCodeEnum
-from .base_strategy import BaseStrategy, EngineState, YearScratch
 from app.services.strategy_engine import tax_rules
+from app.services.strategy_engine.engine import register
 from app.services.strategy_engine.strategies.gradual_meltdown import (
-    TOL,
-    MAX_ITER,
     ASSUMED_INFLATION,
+    MAX_ITER,
     TAXABLE_PORTION_NONREG_GROWTH,
+    TOL,
 )
 
+from .base_strategy import BaseStrategy, EngineState, YearScratch
+
+
+@register(StrategyCodeEnum.SEQ.value)
 class SpousalEqualizationStrategy(BaseStrategy):
     code = StrategyCodeEnum.SEQ
     complexity = 3

--- a/backend/tests/unit/services/strategy_engine/test_registry.py
+++ b/backend/tests/unit/services/strategy_engine/test_registry.py
@@ -1,0 +1,14 @@
+import unittest
+
+from app.data_models.scenario import StrategyCodeEnum
+from app.services.strategy_engine.engine import _STRATEGY_REGISTRY
+
+
+class StrategyRegistryTests(unittest.TestCase):
+    def test_all_expected_strategies_registered(self) -> None:
+        expected = {c.value for c in StrategyCodeEnum if c != StrategyCodeEnum.MIN}
+        self.assertTrue(expected.issubset(set(_STRATEGY_REGISTRY.keys())))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- decorate every strategy class with `register` decorator
- import all strategy modules in the engine so decorators run
- verify registry via a new unit test

## Testing
- `ruff check backend/app/services/strategy_engine/strategies/bracket_filling.py backend/app/services/strategy_engine/strategies/delay_cpp_oas.py backend/app/services/strategy_engine/strategies/early_rrif_conversion.py backend/app/services/strategy_engine/strategies/gradual_meltdown.py backend/app/services/strategy_engine/strategies/interest_offset_loan.py backend/app/services/strategy_engine/strategies/lump_sum_withdrawal.py backend/app/services/strategy_engine/strategies/spousal_equalization.py backend/app/services/strategy_engine/engine.py backend/tests/unit/services/strategy_engine/test_registry.py --fix`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*