### PR TITLE
Fix rrif minimum call args

### DIFF
--- a/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
+++ b/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
@@ -102,7 +102,7 @@ class DelayCppOasStrategy(BaseStrategy):
         min_rrif = Decimal(
             str(
                 tax_rules.get_rrif_min_withdrawal_amount(
-                    float(begin_rrif), rrif_age
+                    float(begin_rrif), rrif_age, td
                 )
             )
         )

--- a/backend/app/services/strategy_engine/strategies/early_rrif_conversion.py
+++ b/backend/app/services/strategy_engine/strategies/early_rrif_conversion.py
@@ -72,7 +72,7 @@ class EarlyRRIFConversionStrategy(BaseStrategy):
             gross_rrif = Decimal(
                 str(
                     tax_rules.get_rrif_min_withdrawal_amount(
-                        float(begin_rrif), age
+                        float(begin_rrif), age, td
                     )
                 )
             )

--- a/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
+++ b/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
@@ -69,7 +69,9 @@ class InterestOffsetStrategy(BaseStrategy):
         rrif_age = min(age, spouse_age_this_year) if spouse_age_this_year else age
         min_rrif = Decimal(
             str(
-                tax_rules.get_rrif_min_withdrawal_amount(float(begin_rrif), rrif_age)
+                tax_rules.get_rrif_min_withdrawal_amount(
+                    float(begin_rrif), rrif_age, td
+                )
             )
         )
 

--- a/backend/app/services/strategy_engine/strategies/lump_sum_withdrawal.py
+++ b/backend/app/services/strategy_engine/strategies/lump_sum_withdrawal.py
@@ -71,7 +71,9 @@ def _run_year(self: LumpSumWithdrawalStrategy, idx: int, state: EngineState) -> 
     rrif_age = min(age, spouse_age_this_year) if spouse_age_this_year else age
     min_rrif = Decimal(
         str(
-            tax_rules.get_rrif_min_withdrawal_amount(float(begin_rrif), rrif_age)
+            tax_rules.get_rrif_min_withdrawal_amount(
+                float(begin_rrif), rrif_age, td
+            )
         )
     )
 


### PR DESCRIPTION
## Summary
- fix callsites of `get_rrif_min_withdrawal_amount` to pass `td`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*