### PR TITLE
Fix strategy tax calls

### DIFF
--- a/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
+++ b/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
@@ -119,12 +119,11 @@ class DelayCppOasStrategy(BaseStrategy):
                 age=age,
             )
             tr = tax_rules.calculate_all_taxes(
-                total_taxable_income=float(taxable),
-                age=age,
-                eligible_pension_income=float(elig),
-                oas_income_included_in_taxable=float(oas_gross),
-                tax_year_data=td,
-                province=self.scenario.province,
+                float(taxable),
+                age,
+                float(elig),
+                td,
+                self.scenario.province,
             )
             tot_tax = Decimal(str(tr["total_income_tax"] + tr["oas_clawback"]))
             return taxable - tot_tax
@@ -150,12 +149,11 @@ class DelayCppOasStrategy(BaseStrategy):
             age=age,
         )
         tax = tax_rules.calculate_all_taxes(
-            total_taxable_income=float(taxable_income),
-            age=age,
-            eligible_pension_income=float(elig_pension),
-            oas_income_included_in_taxable=float(oas_gross),
-            tax_year_data=td,
-            province=self.scenario.province,
+            float(taxable_income),
+            age,
+            float(elig_pension),
+            td,
+            self.scenario.province,
         )
 
         total_tax = Decimal(str(tax["total_income_tax"] + tax["oas_clawback"]))

--- a/backend/app/services/strategy_engine/strategies/early_rrif_conversion.py
+++ b/backend/app/services/strategy_engine/strategies/early_rrif_conversion.py
@@ -89,12 +89,11 @@ class EarlyRRIFConversionStrategy(BaseStrategy):
         )
 
         tax = tax_rules.calculate_all_taxes(
-            total_taxable_income=float(taxable_income),
-            age=age,
-            eligible_pension_income=float(elig_pension),
-            oas_income_included_in_taxable=float(oas_gross),
-            tax_year_data=td,
-            province=self.scenario.province,
+            float(taxable_income),
+            age,
+            float(elig_pension),
+            td,
+            self.scenario.province,
         )
 
         total_tax = Decimal(str(tax["total_income_tax"] + tax["oas_clawback"]))

--- a/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
+++ b/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
@@ -97,12 +97,11 @@ class InterestOffsetStrategy(BaseStrategy):
                 age=age,
             )
             tr = tax_rules.calculate_all_taxes(
-                total_taxable_income=float(taxable),
-                age=age,
-                eligible_pension_income=float(elig),
-                oas_income_included_in_taxable=float(oas_gross),
-                tax_year_data=td,
-                province=self.scenario.province,
+                float(taxable),
+                age,
+                float(elig),
+                td,
+                self.scenario.province,
             )
             tot_tax = Decimal(str(tr["total_income_tax"] + tr["oas_clawback"]))
             # cash in hand = gross incomes – tax – interest
@@ -142,12 +141,11 @@ class InterestOffsetStrategy(BaseStrategy):
             age=age,
         )
         tr = tax_rules.calculate_all_taxes(
-            total_taxable_income=float(taxable_income),
-            age=age,
-            eligible_pension_income=float(elig_pension),
-            oas_income_included_in_taxable=float(oas_gross),
-            tax_year_data=td,
-            province=self.scenario.province,
+            float(taxable_income),
+            age,
+            float(elig_pension),
+            td,
+            self.scenario.province,
         )
         total_tax = Decimal(str(tr["total_income_tax"] + tr["oas_clawback"]))
         after_tax_income = taxable_income - total_tax

--- a/backend/app/services/strategy_engine/strategies/lump_sum_withdrawal.py
+++ b/backend/app/services/strategy_engine/strategies/lump_sum_withdrawal.py
@@ -91,12 +91,11 @@ def _run_year(self: LumpSumWithdrawalStrategy, idx: int, state: EngineState) -> 
             age=age,
         )
         tr = tax_rules.calculate_all_taxes(
-            total_taxable_income=float(taxable),
-            age=age,
-            eligible_pension_income=float(elig),
-            oas_income_included_in_taxable=float(oas_gross),
-            tax_year_data=td,
-            province=self.scenario.province,
+            float(taxable),
+            age,
+            float(elig),
+            td,
+            self.scenario.province,
         )
         tot_tax = Decimal(str(tr["total_income_tax"] + tr["oas_clawback"]))
         return taxable - tot_tax
@@ -131,12 +130,11 @@ def _run_year(self: LumpSumWithdrawalStrategy, idx: int, state: EngineState) -> 
         age=age,
     )
     tax = tax_rules.calculate_all_taxes(
-        total_taxable_income=float(taxable_income),
-        age=age,
-        eligible_pension_income=float(elig_pension),
-        oas_income_included_in_taxable=float(oas_gross),
-        tax_year_data=td,
-        province=self.scenario.province,
+        float(taxable_income),
+        age,
+        float(elig_pension),
+        td,
+        self.scenario.province,
     )
 
     total_tax = Decimal(str(tax["total_income_tax"] + tax["oas_clawback"]))


### PR DESCRIPTION
## Summary
- call `calculate_all_taxes` using positional arguments in strategy modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*