### PR TITLE
Add display names for strategies

### DIFF
--- a/backend/app/services/strategy_engine/strategies/bracket_filling.py
+++ b/backend/app/services/strategy_engine/strategies/bracket_filling.py
@@ -31,6 +31,7 @@ TAXABLE_PORTION_NONREG_GROWTH = Decimal("0.40")
 @register(StrategyCodeEnum.BF.value)
 class BracketFillingStrategy(BaseStrategy):
     code = StrategyCodeEnum.BF
+    display_name = "Bracket Filling"
     complexity = 2
 
     def validate_params(self) -> None:  # noqa: D401

--- a/backend/app/services/strategy_engine/strategies/gradual_meltdown.py
+++ b/backend/app/services/strategy_engine/strategies/gradual_meltdown.py
@@ -40,6 +40,7 @@ TOL = Decimal("1")  # $1 tolerance for cash shortfall
 @register(StrategyCodeEnum.GM.value)
 class GradualMeltdownStrategy(BaseStrategy):
     code = StrategyCodeEnum.GM
+    display_name = "Gradual Meltdown"
     complexity = 1
 
     # ------------------------------------------------------------------ #
@@ -223,6 +224,7 @@ class EmptyByXStrategy(GradualMeltdownStrategy):
     """Variant requiring target_depletion_age parameter."""
 
     code = StrategyCodeEnum.EBX
+    display_name = "Empty by Target Age"
     complexity = 2
 
     def validate_params(self) -> None:  # noqa: D401

--- a/backend/app/services/strategy_engine/strategies/spousal_equalization.py
+++ b/backend/app/services/strategy_engine/strategies/spousal_equalization.py
@@ -44,6 +44,7 @@ from .base_strategy import BaseStrategy, EngineState, YearScratch
 @register(StrategyCodeEnum.SEQ.value)
 class SpousalEqualizationStrategy(BaseStrategy):
     code = StrategyCodeEnum.SEQ
+    display_name = "Spousal Equalisation"
     complexity = 3
 
     def validate_params(self) -> None:  # noqa: D401

--- a/backend/tests/unit/services/strategy_engine/test_strategy_display.py
+++ b/backend/tests/unit/services/strategy_engine/test_strategy_display.py
@@ -1,0 +1,18 @@
+import unittest
+
+from app.data_models.scenario import StrategyCodeEnum
+from app.main import _strategy_display
+from app.services.strategy_engine.engine import _STRATEGY_REGISTRY
+
+
+class StrategyDisplayTests(unittest.TestCase):
+    def test_display_name_lookup(self) -> None:
+        for code in StrategyCodeEnum:
+            if code == StrategyCodeEnum.MIN:
+                continue
+            cls = _STRATEGY_REGISTRY[code.value]
+            self.assertEqual(_strategy_display(code), getattr(cls, "display_name", code.value))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add user-facing `display_name` class attributes for strategy classes
- test `_strategy_display()` utility with all strategy codes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*