### PR TITLE
Fix ResultSummary generation

### DIFF
--- a/backend/app/data_models/results.py
+++ b/backend/app/data_models/results.py
@@ -262,6 +262,9 @@ class ResultSummary(BaseModel):
     final_estate: confloat(ge=0)
     yearly_balances: List[YearlyBalance] = []
 
+    class Config:
+        use_enum_values = True
+
 
 # --------------------------------------------------------------------------- #
 # API Response Wrappers for Simulation Results


### PR DESCRIPTION
## Summary
- adjust imports in engine to use YearlyBalance and strategy metadata
- build `ResultSummary` using new SummaryMetrics fields
- default to `net_value_to_heirs_after_final_taxes_pv` when available
- ensure serialization of ResultSummary by enabling `use_enum_values`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `ruff check .` *(fails: found lint errors)*