### PR TITLE
Add strategy charts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
     "@hookform/resolvers": "^3.3.4",
     "yup": "^1.2.0",
     "classnames": "^2.3.2",
-    "@floating-ui/dom": "^1.6.2"
+    "@floating-ui/dom": "^1.6.2",
+    "recharts": "^2.9.0"
 
   },
   "devDependencies": {

--- a/frontend/src/components/ResultsPage.tsx
+++ b/frontend/src/components/ResultsPage.tsx
@@ -1,5 +1,15 @@
 import React, { useMemo } from 'react';
-import { Box, Typography, Table, TableBody, TableCell, TableHead, TableRow, Button } from '@mui/material';
+import {
+  Box,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Button,
+} from '@mui/material';
+import StrategyChart from './StrategyChart';
 
 import type { ComparisonResponseItem } from '../types/api';
 
@@ -139,13 +149,17 @@ const ResultsPage: React.FC<ResultsPageProps> = ({
         </TableBody>
       </Table>
 
-      {/* Placeholder for visuals (charts) */}
       <Box my={3}>
-        <Typography variant="subtitle1">Strategy Outcomes Visualized:</Typography>
-        {/* For each strategy, we could include a chart (e.g., portfolio value over time, spending over time, etc.) */}
-        {/* For brevity, actual chart implementation is omitted. In practice, use a chart library (like recharts or Chart.js) to plot results. */}
-        {/* Example placeholder: */}
-        {/* results.map(res => <StrategyChart key={res.strategy_code} data={res.yearly_balances} title={res.strategy_name} />) */}
+        <Typography variant="subtitle1" gutterBottom>
+          Strategy Outcomes Visualized:
+        </Typography>
+        {processedResults.map((res: ComparisonResponseItem) => (
+          <StrategyChart
+            key={res.strategy_code}
+            title={res.strategy_name}
+            data={res.yearly_balances || []}
+          />
+        ))}
       </Box>
 
       {/* Navigation Buttons */}

--- a/frontend/src/components/StrategyChart.tsx
+++ b/frontend/src/components/StrategyChart.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts';
+import { Box, Typography } from '@mui/material';
+import type { ComparisonResponseItem } from '../types/api';
+
+export type YearlyBalance = NonNullable<ComparisonResponseItem['yearly_balances']>[number];
+
+interface StrategyChartProps {
+  title: string;
+  data: YearlyBalance[];
+}
+
+const StrategyChart: React.FC<StrategyChartProps> = ({ title, data }) => {
+  return (
+    <Box my={2}>
+      <Typography variant="subtitle2" align="center" gutterBottom>
+        {title}
+      </Typography>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+          <XAxis dataKey="year" />
+          <YAxis />
+          <Tooltip formatter={(value: number) => `$${value.toLocaleString()}`} />
+          <Legend />
+          <Line type="monotone" dataKey="portfolio_end" name={title} stroke="#8884d8" dot={false} />
+        </LineChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+};
+
+export default StrategyChart;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -63,7 +63,11 @@ export interface SummaryMetrics {
 export interface ComparisonResponseItem {
   strategy_code: string;
   strategy_name: string;
-  yearly_results: unknown[]; // YearlyResult not yet typed
+  yearly_results?: unknown[]; // YearlyResult not yet typed
+  yearly_balances?: { year: number; portfolio_end: number }[];
   summary: SummaryMetrics;
+  total_taxes?: number;
+  total_spending?: number;
+  final_estate?: number;
 }
 


### PR DESCRIPTION
## Summary
- add `recharts` to frontend dependencies
- implement `<StrategyChart>` using Recharts
- display strategy charts in `ResultsPage`
- extend API types with yearly balance fields

## Testing
- `npm test` *(fails: jest not found)*