### PR TITLE
Expose debug strategies endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,3 +1,14 @@
 # retirement_planner_app
 
 Project description here.
+
+## Debug API
+
+For troubleshooting, the backend exposes a debug route listing registered
+withdrawal strategies:
+
+```
+GET /api/v1/debug/strategies
+```
+
+The endpoint returns a JSON array of strategy codes such as `"GM"`.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -289,12 +289,26 @@ async def simulate_mc(req: SimulateRequest):
 
     return {"request_id": req.request_id, "paths": paths, "mc_summary": mc_summary}
 
+
 # ---------- health ---------------------------------------------------
 @router.get("/health", tags=["Health"])
 async def health():
     return {"status": "healthy"}
 
+
+# ------------------------------------------------------------------ #
+# debug router                                                       #
+# ------------------------------------------------------------------ #
+debug_router = APIRouter(prefix="/debug", tags=["Debug"])
+
+
+@debug_router.get("/strategies")
+async def debug_strategies() -> List[str]:
+    """Return list of registered strategy codes for debugging."""
+    return list(_STRATEGY_REGISTRY.keys())
+
 # ------------------------------------------------------------------ #
 # mount legacy router under configurable prefix (default: /api)
 # ------------------------------------------------------------------ #
 app.include_router(router, prefix=settings.API_PREFIX)
+app.include_router(debug_router, prefix=settings.API_PREFIX)

--- a/backend/main.py
+++ b/backend/main.py
@@ -292,7 +292,20 @@ async def simulate_mc(req: SimulateRequest):
 async def health():
     return {"status": "healthy"}
 
+
+# ------------------------------------------------------------------ #
+# debug router                                                       #
+# ------------------------------------------------------------------ #
+debug_router = APIRouter(prefix="/debug", tags=["Debug"])
+
+
+@debug_router.get("/strategies")
+async def debug_strategies() -> List[str]:
+    """Return list of registered strategy codes for debugging."""
+    return list(_STRATEGY_REGISTRY.keys())
+
 # ------------------------------------------------------------------ #
 # mount legacy router under configurable prefix (default: /api)
 # ------------------------------------------------------------------ #
 app.include_router(router, prefix=settings.API_PREFIX)
+app.include_router(debug_router, prefix=settings.API_PREFIX)

--- a/backend/tests/integration/api/v1/test_debug.py
+++ b/backend/tests/integration/api/v1/test_debug.py
@@ -1,0 +1,10 @@
+import pytest
+
+@pytest.mark.asyncio
+async def test_debug_strategies_endpoint(client):
+    resp = await client.get('/api/v1/debug/strategies')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert 'GM' in data
+    assert len(data) > 0


### PR DESCRIPTION
## Summary
- add `/api/v1/debug/strategies` endpoint
- test debug strategies route
- mention debug API in backend README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*