### PR TITLE
Resolve conflicting 2025 tax figures

### DIFF
--- a/backend/data/tax_years.yml
+++ b/backend/data/tax_years.yml
@@ -11,7 +11,7 @@
   # --------------------------------------------------------------------------
   # Federal personal taxes
   # --------------------------------------------------------------------------
-  federal_personal_amount: 15978
+  federal_personal_amount: 15705
   federal_personal_amount_min: 14156
   federal_personal_amount_phaseout_start: 173205
   federal_personal_amount_phaseout_end: 246752
@@ -21,9 +21,9 @@
 
   # 2025 federal brackets
   federal_tax_brackets:
-    - {upto:  55868, rate: 0.1500}
-    - {upto: 111733, rate: 0.2050}
-    - {upto: 173205, rate: 0.2600}
+    - {upto:  58579, rate: 0.1500}
+    - {upto: 117158, rate: 0.2050}
+    - {upto: 172620, rate: 0.2600}
     - {upto: 246752, rate: 0.2900}
     - {upto: null,   rate: 0.3300}
 
@@ -95,7 +95,7 @@
   # --------------------------------------------------------------------------
   # Ontario personal taxes
   # --------------------------------------------------------------------------
-  ontario_personal_amount: 12122
+  ontario_personal_amount: 11865
   ontario_age_amount: 5750
   ontario_age_amount_threshold: 43179
   ontario_pension_income_credit_max: 1500
@@ -107,9 +107,9 @@
     - {upto: 220000, rate: 0.1216}
     - {upto: null,   rate: 0.1316}
 
-  ontario_surtax_threshold_1: 5315
+  ontario_surtax_threshold_1: 5554
   ontario_surtax_rate_1:      0.20
-  ontario_surtax_threshold_2: 6802
+  ontario_surtax_threshold_2: 7108
   ontario_surtax_rate_2:      0.36
 
 ###############################################################################

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,6 +12,9 @@ from app.utils import year_data_loader
 
 YEAR_2025 = {
     'federal_personal_amount': 15705,
+    'federal_personal_amount_min': 14156,
+    'federal_personal_amount_phaseout_start': 173205,
+    'federal_personal_amount_phaseout_end': 246752,
     'federal_age_amount': 8396,
     'federal_age_amount_threshold': 43179,
     'federal_pension_income_credit_max': 2000,

--- a/backend/tests/unit/services/strategy_engine/strategies/test_gradual_meltdown.py
+++ b/backend/tests/unit/services/strategy_engine/strategies/test_gradual_meltdown.py
@@ -1,8 +1,15 @@
+from app.data_models.scenario import (
+    ScenarioInput,
+    StrategyCodeEnum,
+    StrategyParamsInput,
+)
 from app.services.strategy_engine.engine import StrategyEngine
-from app.data_models.scenario import ScenarioInput, StrategyParamsInput, StrategyCodeEnum
 
 YEAR_2025 = {
     'federal_personal_amount': 15705,
+    'federal_personal_amount_min': 14156,
+    'federal_personal_amount_phaseout_start': 173205,
+    'federal_personal_amount_phaseout_end': 246752,
     'federal_age_amount': 8396,
     'federal_age_amount_threshold': 43179,
     'federal_pension_income_credit_max': 2000,

--- a/backend/tests/unit/test_scenario_defaults.py
+++ b/backend/tests/unit/test_scenario_defaults.py
@@ -1,4 +1,5 @@
 import importlib
+
 import pytest
 
 from app.data_models.scenario import ScenarioInput, SimulateRequest, StrategyCodeEnum
@@ -27,5 +28,5 @@ def test_load_tax_year_data_parses_yaml(monkeypatch):
     import app.utils.year_data_loader as ydl
     ydl = importlib.reload(ydl)
     data = ydl.load_tax_year_data(2025, "ON")
-    assert data["federal_personal_amount"] == 15978
+    assert data["federal_personal_amount"] == 15705
 

--- a/backend/tests/unit/test_tax.py
+++ b/backend/tests/unit/test_tax.py
@@ -1,9 +1,11 @@
-import pytest
 from decimal import Decimal
+
+import pytest
+
 from app.services.strategy_engine import tax_rules
 
 TD_2025 = {
-    'federal_personal_amount': 15978,
+    'federal_personal_amount': 15705,
     'federal_personal_amount_min': 14156,
     'federal_personal_amount_phaseout_start': 173205,
     'federal_personal_amount_phaseout_end': 246752,
@@ -11,9 +13,9 @@ TD_2025 = {
     'federal_age_amount_threshold': 43179,
     'federal_pension_income_credit_max': 2000,
     'federal_tax_brackets': [
-        {'upto': 55868, 'rate': 0.15},
-        {'upto': 111733, 'rate': 0.205},
-        {'upto': 173205, 'rate': 0.26},
+        {'upto': 58579, 'rate': 0.15},
+        {'upto': 117158, 'rate': 0.205},
+        {'upto': 172620, 'rate': 0.26},
         {'upto': 246752, 'rate': 0.29},
         {'upto': None, 'rate': 0.33},
     ],
@@ -25,7 +27,7 @@ TD_2025 = {
     'cpp_deferral_factor_per_year': 0.084,
     'cpp_early_factor_per_year': 0.072,
     'rrif_table': {},
-    'ontario_personal_amount': 12122,
+    'ontario_personal_amount': 11865,
     'ontario_age_amount': 5750,
     'ontario_age_amount_threshold': 43179,
     'ontario_pension_income_credit_max': 1500,
@@ -36,39 +38,39 @@ TD_2025 = {
         {'upto': 220000, 'rate': 0.1216},
         {'upto': None, 'rate': 0.1316},
     ],
-    'ontario_surtax_threshold_1': 5315,
+    'ontario_surtax_threshold_1': 5554,
     'ontario_surtax_rate_1': 0.20,
-    'ontario_surtax_threshold_2': 6802,
+    'ontario_surtax_threshold_2': 7108,
     'ontario_surtax_rate_2': 0.36,
 }
 
 CASES = {
     40000: {
-        'federal_tax': Decimal('3603.30'),
-        'provincial_tax': Decimal('1407.84'),
+        'federal_tax': Decimal('3644.25'),
+        'provincial_tax': Decimal('1420.82'),
         'provincial_surtax': Decimal('0.00'),
-        'total_income_tax': Decimal('5011.14'),
+        'total_income_tax': Decimal('5065.07'),
         'oas_clawback': Decimal('0.00'),
     },
     95000: {
-        'federal_tax': Decimal('14005.56'),
-        'provincial_tax': Decimal('6102.26'),
-        'provincial_surtax': Decimal('131.21'),
-        'total_income_tax': Decimal('20107.82'),
+        'federal_tax': Decimal('13897.40'),
+        'provincial_tax': Decimal('6070.04'),
+        'provincial_surtax': Decimal('86.01'),
+        'total_income_tax': Decimal('19967.44'),
         'oas_clawback': Decimal('231.90'),
     },
     120000: {
-        'federal_tax': Decimal('19585.24'),
-        'provincial_tax': Decimal('9547.92'),
-        'provincial_surtax': Decimal('945.54'),
-        'total_income_tax': Decimal('29133.17'),
+        'federal_tax': Decimal('19178.71'),
+        'provincial_tax': Decimal('9468.81'),
+        'provincial_surtax': Decimal('853.45'),
+        'total_income_tax': Decimal('28647.53'),
         'oas_clawback': Decimal('3981.90'),
     },
     280000: {
-        'federal_tax': Decimal('65992.32'),
-        'provincial_tax': Decimal('36416.08'),
-        'provincial_surtax': Decimal('8057.70'),
-        'total_income_tax': Decimal('102408.40'),
+        'federal_tax': Decimal('65562.39'),
+        'provincial_tax': Decimal('36336.97'),
+        'provincial_surtax': Decimal('7965.61'),
+        'total_income_tax': Decimal('101899.36'),
         'oas_clawback': Decimal('8250.00'),
     },
 }

--- a/tax/2025.yaml
+++ b/tax/2025.yaml
@@ -3,6 +3,9 @@
   # Federal personal taxes
   # --------------------------------------------------------------------------
   federal_personal_amount: 15705
+  federal_personal_amount_min: 14156
+  federal_personal_amount_phaseout_start: 173205
+  federal_personal_amount_phaseout_end: 246752
   federal_age_amount: 8396
   federal_age_amount_threshold: 43179
   federal_pension_income_credit_max: 2000


### PR DESCRIPTION
## Summary
- sync federal and Ontario constants between tax files
- extend `tax/2025.yaml` with BPA phaseout fields
- update fixtures and tests for the unified 2025 values

## Testing
- `ruff check backend/tests/conftest.py backend/tests/unit/test_tax.py backend/tests/unit/test_scenario_defaults.py backend/tests/unit/services/strategy_engine/strategies/test_gradual_meltdown.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*