### PR TITLE
Support deferred OAS clawback

### DIFF
--- a/backend/app/services/strategy_engine/strategies/bracket_filling.py
+++ b/backend/app/services/strategy_engine/strategies/bracket_filling.py
@@ -120,7 +120,11 @@ class BracketFillingStrategy(BaseStrategy):
             age, float(gross_rrif), float(db_pension)
         )
         tax = tax_rules.calculate_all_taxes(
-            float(taxable_income), age, float(elig_pension), td
+            float(taxable_income),
+            age,
+            float(elig_pension),
+            td,
+            oas_start_age=oas_start_age,
         )
         total_tax = Decimal(str(tax["total_income_tax"] + tax["oas_clawback"]))
         after_tax_income = taxable_income - total_tax

--- a/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
+++ b/backend/app/services/strategy_engine/strategies/delay_cpp_oas.py
@@ -124,6 +124,7 @@ class DelayCppOasStrategy(BaseStrategy):
                 float(elig),
                 td,
                 self.scenario.province,
+                oas_start_age=oas_start,
             )
             tot_tax = Decimal(str(tr["total_income_tax"] + tr["oas_clawback"]))
             return taxable - tot_tax
@@ -154,6 +155,7 @@ class DelayCppOasStrategy(BaseStrategy):
             float(elig_pension),
             td,
             self.scenario.province,
+            oas_start_age=oas_start,
         )
 
         total_tax = Decimal(str(tax["total_income_tax"] + tax["oas_clawback"]))

--- a/backend/tests/unit/test_tax.py
+++ b/backend/tests/unit/test_tax.py
@@ -81,3 +81,20 @@ def test_tax_calculations(income):
     expected = CASES[income]
     for key, val in expected.items():
         assert Decimal(str(res[key])).quantize(Decimal('0.01')) == val
+
+
+def test_oas_clawback_deferral():
+    start_age = 70
+    res = tax_rules.calculate_all_taxes(
+        280000,
+        age=start_age,
+        pension_inc=0,
+        td=TD_2025,
+        oas_start_age=start_age,
+    )
+    expected = tax_rules.get_adjusted_oas_benefit(
+        TD_2025['oas_max_benefit_at_65'], start_age, TD_2025
+    )
+    assert Decimal(str(res['oas_clawback'])).quantize(Decimal('0.01')) == Decimal(
+        str(expected)
+    ).quantize(Decimal('0.01'))


### PR DESCRIPTION
## Summary
- handle deferred OAS start age in tax rules
- adjust Delay CPP/OAS and Bracket-Filling strategies
- add unit test for OAS deferral clawback

## Testing
- `ruff check .` *(fails: Import block is unsorted or un-formatted)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*