### PR TITLE
Improve YAML loader error messages and document PyYAML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         run: pip install poetry
       - name: Install dependencies
         run: poetry install
+      - name: Check PyYAML availability
+        run: python -c "import yaml, sys; print('PyYAML:', yaml.__version__)"
       - name: Run lint
         run: poetry run ruff check .
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,5 +15,7 @@ jobs:
       - uses: abatilo/actions-poetry@v2
       - name: Install dependencies
         run: cd backend && poetry install --no-interaction
+      - name: Check PyYAML availability
+        run: python -c "import yaml, sys; print('PyYAML:', yaml.__version__)"
       - name: Run tests
         run: cd backend && poetry run pytest

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,6 +2,12 @@
 
 Project description here.
 
+## Dependencies
+
+The backend reads tax tables from YAML files. A real installation of
+**PyYAML** is therefore required. Continuous integration checks that
+`import yaml` succeeds, and `poetry install` will provide the package.
+
 ## Debug API
 
 For troubleshooting, the backend exposes a debug route listing registered

--- a/backend/app/utils/year_data_loader.py
+++ b/backend/app/utils/year_data_loader.py
@@ -55,7 +55,7 @@ def _normalise_year_block(block: dict) -> Dict[str, TaxYearData]:
     return {"ON": block}  # treat flat mapping as Ontario
 
 
-def _parse_stream(fh) -> Dict[str, Any]:
+def _parse_stream(fh, source: str | Path | None = None) -> Dict[str, Any]:
     """
     Parse a file-handle:
 
@@ -78,9 +78,10 @@ def _parse_stream(fh) -> Dict[str, Any]:
     try:
         return json.loads(text) or {}
     except json.JSONDecodeError as exc:  # neither YAML nor JSON worked
+        loc = f" at {source}" if source else ""
         raise ValueError(
-            "Unable to parse tax tables: PyYAML missing / stubbed and "
-            "file is not valid JSON.  Install `pyyaml` or convert the "
+            "Unable to parse tax tables" + loc + ": PyYAML missing / stubbed "
+            "and file is not valid JSON. Install `pyyaml` or convert the "
             "YAML file to JSON syntax."
         ) from exc
 
@@ -91,7 +92,7 @@ def _load_yaml() -> Dict[int, Dict[str, TaxYearData]]:
         raise FileNotFoundError(f"tax_years.yml not found at {DATA_PATH}")
 
     with DATA_PATH.open(encoding="utf-8") as fh:
-        raw: Dict[str, Any] = _parse_stream(fh)
+        raw: Dict[str, Any] = _parse_stream(fh, DATA_PATH)
 
     out: Dict[int, Dict[str, TaxYearData]] = {}
     for yr_str, block in raw.items():
@@ -106,7 +107,7 @@ def _load_single_year(year: int) -> Dict[str, TaxYearData] | None:
         return None
 
     with path.open(encoding="utf-8") as fh:
-        raw: Dict[str, Any] = _parse_stream(fh)
+        raw: Dict[str, Any] = _parse_stream(fh, path)
 
     if str(year) in raw:
         block = raw[str(year)]

--- a/backend/tests/unit/utils/test_year_data_loader.py
+++ b/backend/tests/unit/utils/test_year_data_loader.py
@@ -1,1 +1,24 @@
-# TODO: Implement Python module
+import importlib
+from pathlib import Path
+import pytest
+
+import app.utils.year_data_loader as ydl
+
+
+def test_parse_stream_json_fallback(monkeypatch, tmp_path):
+    monkeypatch.setattr(ydl, "yaml", None)
+    p = tmp_path / "simple.yaml"
+    p.write_text('{"2025": {"ON": {"flag": 1}}}')
+    with p.open() as fh:
+        data = ydl._parse_stream(fh, p)
+    assert data["2025"]["ON"]["flag"] == 1
+
+
+def test_parse_stream_error_message(monkeypatch, tmp_path):
+    monkeypatch.setattr(ydl, "yaml", None)
+    p = tmp_path / "bad.yaml"
+    p.write_text("key: value\n# comment")
+    with p.open() as fh:
+        with pytest.raises(ValueError) as exc:
+            ydl._parse_stream(fh, p)
+    assert str(p) in str(exc.value)


### PR DESCRIPTION
## Summary
- add PyYAML availability check to CI workflows
- mention PyYAML dependency in backend README
- improve `_parse_stream` error messaging and show file path
- expand tests for fallback JSON parser

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*