### PR TITLE
Handle simulation errors gracefully

### DIFF
--- a/backend/app/data_models/results.py
+++ b/backend/app/data_models/results.py
@@ -278,8 +278,16 @@ class SimulationResponse(BaseModel):
     yearly_results: List[YearlyResult] = Field(
         ..., description="List of detailed results for each year of the projection."
     )
-    summary: SummaryMetrics = Field(..., description="Aggregated summary metrics for the entire strategy.")
-    request_id: UUID = Field(..., description="Unique ID for the simulation request, for tracing.")
+    summary: SummaryMetrics = Field(
+        ..., description="Aggregated summary metrics for the entire strategy."
+    )
+    request_id: UUID = Field(
+        ..., description="Unique ID for the simulation request, for tracing."
+    )
+    error_detail: str | None = Field(
+        default=None,
+        description="Error message if the strategy failed to run.",
+    )
 
     class Config:
         use_enum_values = True # Ensures enum values are used in serialization
@@ -289,7 +297,8 @@ class SimulationResponse(BaseModel):
                 "strategy_name": "Gradual Meltdown",
                 "yearly_results": [YearlyResult.Config.json_schema_extra["example"]],
                 "summary": SummaryMetrics.Config.json_schema_extra["example"],
-                "request_id": "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+                "request_id": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
+                "error_detail": None
             }
         }
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -198,8 +198,15 @@ async def simulate(req: SimulateRequest):
     # Apply params to scenario before running
     scenario_with_params = req.scenario.copy(deep=True)
     scenario_with_params.strategy_params_override = params
-    
-    yearly, summary = engine.run(req.strategy_code, scenario_with_params)
+
+    try:
+        yearly, summary = engine.run(req.strategy_code, scenario_with_params)
+        error_detail = None
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("simulate error for %s: %s", req.strategy_code, exc)
+        yearly = []
+        summary = _create_default_summary_metrics(req.strategy_code)
+        error_detail = str(exc)
 
     return SimulationApiResponse(
         request_id=req.request_id,
@@ -207,6 +214,7 @@ async def simulate(req: SimulateRequest):
         strategy_name=_strategy_display(req.strategy_code),
         yearly_results=yearly,
         summary=summary,
+        error_detail=error_detail,
     )
 
 # ---------- deterministic compare -----------------------------------

--- a/backend/tests/integration/api/v1/test_simulation_controller.py
+++ b/backend/tests/integration/api/v1/test_simulation_controller.py
@@ -1,62 +1,41 @@
 import pytest
-from httpx import AsyncClient
-
-from app.main import app
-
-VALID_SCENARIO = {
-    "age": 65,
-    "rrsp_balance": 500000,
-    "defined_benefit_pension": 20000,
-    "cpp_at_65": 12000,
-    "oas_at_65": 8000,
-    "tfsa_balance": 100000,
-    "desired_spending": 60000,
-    "expect_return_pct": 5,
-    "stddev_return_pct": 8,
-    "life_expectancy_years": 25,
-    "province": "ON",
-    "goal": "maximize_spending",
-}
-
-
-@pytest.mark.asyncio
-async def test_simulate_missing_scenario():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.post("/simulate", json={"strategy_code": "GM"})
-    assert response.status_code == 422
-    assert response.json()["detail"] == "scenario is required"
-
-
-@pytest.mark.asyncio
-async def test_compare_missing_scenario():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.post("/compare", json={"strategies": ["GM"]})
-    assert response.status_code == 422
-    assert response.json()["detail"] == "scenario is required"
-
-
-@pytest.mark.asyncio
-async def test_compare_empty_strategies():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.post(
-            "/compare", json={"scenario": VALID_SCENARIO, "strategies": []}
-        )
-    assert response.status_code == 400
-    assert response.json()["detail"] == "strategies list cannot be empty"
-
-
-@pytest.mark.asyncio
-async def test_simulate_mc_missing_scenario():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.post(
-            "/simulate_mc", json={"strategy_code": "GM"}
-        )
-    assert response.status_code == 422
-    assert response.json()["detail"] == "scenario is required"
-=======
+import app.main as main_app
 from app.data_models.scenario import ScenarioInput, StrategyCodeEnum
 
 EXAMPLE_SCENARIO = ScenarioInput.Config.json_schema_extra["example"]
+
+@pytest.mark.asyncio
+async def test_simulate_missing_scenario(client):
+    resp = await client.post("/api/v1/simulate", json={"strategy_code": "GM"})
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "scenario is required"
+
+
+@pytest.mark.asyncio
+async def test_compare_missing_scenario(client):
+    resp = await client.post("/api/v1/compare", json={"strategies": ["GM"]})
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "scenario is required"
+
+
+@pytest.mark.asyncio
+async def test_compare_empty_strategies(client):
+    resp = await client.post(
+        "/api/v1/compare",
+        json={"scenario": EXAMPLE_SCENARIO, "strategies": []},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "strategies list cannot be empty"
+
+
+@pytest.mark.asyncio
+async def test_simulate_mc_missing_scenario(client):
+    resp = await client.post(
+        "/api/v1/simulate_mc", json={"strategy_code": "GM"}
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "scenario is required"
+
 
 @pytest.mark.parametrize("code", [c for c in StrategyCodeEnum])
 async def test_simulate_success(client, code):
@@ -67,6 +46,7 @@ async def test_simulate_success(client, code):
     assert body["strategy_code"] == code.value
     assert body["yearly_results"]
 
+
 @pytest.mark.parametrize("code", [c for c in StrategyCodeEnum])
 async def test_simulate_missing_param_422(client, code):
     bad = EXAMPLE_SCENARIO.copy()
@@ -75,3 +55,18 @@ async def test_simulate_missing_param_422(client, code):
     resp = await client.post("/api/v1/simulate", json=payload)
     assert resp.status_code == 422
 
+
+@pytest.mark.asyncio
+async def test_simulate_engine_error_returns_defaults(client, monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(main_app.engine, "run", boom)
+
+    payload = {"scenario": EXAMPLE_SCENARIO, "strategy_code": "GM"}
+    resp = await client.post("/api/v1/simulate", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["yearly_results"] == []
+    assert data["error_detail"] == "boom"
+    assert data["summary"]["lifetime_tax_paid_nominal"] == 0.0


### PR DESCRIPTION
## Summary
- extend `SimulationResponse` with optional `error_detail`
- return default metrics when `engine.run` fails in `/simulate`
- mirror the same logic in root `main.py`
- rewrite integration tests and add coverage for error handling

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*