### PR TITLE
Fix simulate endpoint parameter handling

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -18,3 +18,18 @@ GET /api/v1/debug/strategies
 ```
 
 The endpoint returns a JSON array of strategy codes such as `"GM"`.
+
+## Simulation Endpoint
+
+The `/api/v1/simulate` route accepts a scenario along with the list of
+strategy codes to evaluate:
+
+```json
+{
+  "scenario": { "age": 65, "rrsp_balance": 500000, "goal": "maximize_spending" },
+  "strategies": ["GM", "MIN"]
+}
+```
+
+It returns an array of `ResultSummary` objects—one for each requested
+strategy.

--- a/backend/app/api/v1/endpoint_simulate.py
+++ b/backend/app/api/v1/endpoint_simulate.py
@@ -1,19 +1,18 @@
 from fastapi import APIRouter
 from typing import List
 
-from app.data_models.scenario import ScenarioInput
+from app.data_models.scenario import CompareRequest
 from app.data_models.results import ResultSummary
 from app.services.strategy_engine.engine import run_strategy_batch
-from app.data_models.scenario import ScenarioInput   # wizard model
 
 
 router = APIRouter(prefix="/api/v1", tags=["simulate"])
 
 
 @router.post("/simulate", response_model=List[ResultSummary])
-async def simulate(scenario: ScenarioInput) -> List[ResultSummary]:
+async def simulate(req: CompareRequest) -> List[ResultSummary]:
     """
-    Run the scenario against all strategies requested in
-    `scenario.strategies` and return an array of ResultSummary.
+    Run the scenario against all strategies provided in ``req.strategies`` and
+    return an array of ``ResultSummary`` objects.
     """
-    return run_strategy_batch(scenario)
+    return run_strategy_batch(req.scenario, req.strategies)

--- a/backend/app/api/v1/simulate.py
+++ b/backend/app/api/v1/simulate.py
@@ -9,11 +9,11 @@ router = APIRouter(prefix="/api/v1", tags=["simulation"])
 @router.post("/simulate")
 def simulate(req: CompareRequest):
     """
-    Run every strategy listed in req.scenario.strategies and
-    return their summary metrics for the front-end wizard.
+    Run every strategy listed in ``req.strategies`` and return their
+    summary metrics for the front-end wizard.
     """
     try:
-        summaries = run_strategy_batch(req.scenario)
+        summaries = run_strategy_batch(req.scenario, req.strategies)
         # run_strategy_batch returns a list of Pydantic models; convert to dicts
         return {"comparisons": [s.dict() for s in summaries]}
     except Exception as exc:

--- a/backend/tests/unit/services/strategy_engine/test_batch/test_run_strategy_batch.py
+++ b/backend/tests/unit/services/strategy_engine/test_batch/test_run_strategy_batch.py
@@ -1,0 +1,23 @@
+from app.data_models.scenario import ScenarioInput, StrategyCodeEnum
+from app.data_models.results import SummaryMetrics
+from app.services.strategy_engine import engine as engine_mod
+
+
+EXAMPLE_SCENARIO = ScenarioInput(**ScenarioInput.Config.json_schema_extra["example"]) 
+
+
+def test_run_strategy_batch_uses_provided_codes(monkeypatch):
+    called = []
+    example_metrics = SummaryMetrics(**SummaryMetrics.Config.json_schema_extra["example"])
+
+    def fake_single(code, scenario, tax_loader=engine_mod.load_tax_year_data):
+        called.append(code)
+        return example_metrics
+
+    monkeypatch.setattr(engine_mod, "run_single_strategy", fake_single)
+
+    codes = [StrategyCodeEnum.GM, StrategyCodeEnum.MIN]
+    results = engine_mod.run_strategy_batch(EXAMPLE_SCENARIO, codes)
+
+    assert called == codes
+    assert [r.strategy_code for r in results] == codes


### PR DESCRIPTION
## Summary
- pass explicit strategy codes to run_strategy_batch instead of pulling from ScenarioInput
- update StrategyEngine and API endpoint to use new signature
- document /api/v1/simulate payload requirements
- update integration tests and add unit test for run_strategy_batch

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*