### PR TITLE
Update interest-offset field names

### DIFF
--- a/frontend/src/components/SimulationForm.tsx
+++ b/frontend/src/components/SimulationForm.tsx
@@ -52,11 +52,11 @@ const schema = yup.object({
       .min(60)
       .max(70)
       .when('$delay', (delay: boolean, s: any) => (delay ? s.required() : s)),
-    interest_rate: yup
+    loan_interest_rate_pct: yup
       .number()
       .typeError('Required')
       .when('$interest', (interest: boolean, s: any) => (interest ? s.required() : s)),
-    loan_pct_rrif: yup
+    loan_amount_as_pct_of_rrif: yup
       .number()
       .typeError('Required')
       .when('$interest', (interest: boolean, s: any) => (interest ? s.required() : s)),
@@ -380,7 +380,7 @@ export default function SimulationForm() {
       {interest && (
         <Box>
           <Controller
-            name="strategy_params.interest_rate"
+            name="strategy_params.loan_interest_rate_pct"
             control={control}
             render={({ field }) => (
               <TextField
@@ -398,8 +398,8 @@ export default function SimulationForm() {
                     <Tooltip id="sim-interest-rate-info" place="top" />
                   </span>
                 }
-                error={!!errors.strategy_params?.interest_rate}
-                helperText={errors.strategy_params?.interest_rate?.message}
+                error={!!errors.strategy_params?.loan_interest_rate_pct}
+                helperText={errors.strategy_params?.loan_interest_rate_pct?.message}
                 type="number"
                 fullWidth
                 margin="normal"
@@ -407,7 +407,7 @@ export default function SimulationForm() {
             )}
           />
           <Controller
-            name="strategy_params.loan_pct_rrif"
+            name="strategy_params.loan_amount_as_pct_of_rrif"
             control={control}
             render={({ field }) => (
               <TextField
@@ -425,8 +425,8 @@ export default function SimulationForm() {
                     <Tooltip id="sim-loan-pct-info" place="top" />
                   </span>
                 }
-                error={!!errors.strategy_params?.loan_pct_rrif}
-                helperText={errors.strategy_params?.loan_pct_rrif?.message}
+                error={!!errors.strategy_params?.loan_amount_as_pct_of_rrif}
+                helperText={errors.strategy_params?.loan_amount_as_pct_of_rrif?.message}
                 type="number"
                 fullWidth
                 margin="normal"

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -15,8 +15,8 @@ export interface StrategyParamsInput {
   target_depletion_age?: number;
   cpp_start_age?: number;
   oas_start_age?: number;
-  interest_rate?: number;
-  loan_pct_rrif?: number;
+  loan_interest_rate_pct?: number;
+  loan_amount_as_pct_of_rrif?: number;
   spouse?: SpouseInfo;
 }
 


### PR DESCRIPTION
## Summary
- rename `interest_rate` -> `loan_interest_rate_pct` in API types and forms
- rename `loan_pct_rrif` -> `loan_amount_as_pct_of_rrif` in API types and forms

## Testing
- `npm test` *(fails: `jest` not found)*
- `poetry run pytest` *(fails: `httpx` missing)*