### PR TITLE
Add basic strategy tests

### DIFF
--- a/backend/tests/unit/services/strategy_engine/strategies/test_bracket_filling.py
+++ b/backend/tests/unit/services/strategy_engine/strategies/test_bracket_filling.py
@@ -1,1 +1,19 @@
-# TODO: Implement Python module
+from copy import deepcopy
+
+from app.data_models.scenario import (
+    ScenarioInput,
+    StrategyCodeEnum,
+    StrategyParamsInput,
+)
+from app.services.strategy_engine.engine import StrategyEngine
+from backend.tests.conftest import YEAR_2025
+
+
+def test_bracket_filling_produces_positive_withdrawal_and_tax():
+    scenario = ScenarioInput(**deepcopy(ScenarioInput.Config.json_schema_extra["example"]))
+    engine = StrategyEngine(tax_year_data_loader=lambda y, p="ON": YEAR_2025)
+    params = scenario.strategy_params_override or StrategyParamsInput()
+    yearly, summary = engine.run(StrategyCodeEnum.BF, scenario, params)
+
+    assert yearly[0].income_sources.rrif_withdrawal > 0
+    assert summary.lifetime_tax_paid_nominal > 0

--- a/backend/tests/unit/services/strategy_engine/strategies/test_delay_cpp_oas.py
+++ b/backend/tests/unit/services/strategy_engine/strategies/test_delay_cpp_oas.py
@@ -1,1 +1,19 @@
-# TODO: Implement Python module
+from copy import deepcopy
+
+from app.data_models.scenario import (
+    ScenarioInput,
+    StrategyCodeEnum,
+    StrategyParamsInput,
+)
+from app.services.strategy_engine.engine import StrategyEngine
+from backend.tests.conftest import YEAR_2025
+
+
+def test_delay_cpp_oas_produces_positive_withdrawal_and_tax():
+    scenario = ScenarioInput(**deepcopy(ScenarioInput.Config.json_schema_extra["example"]))
+    engine = StrategyEngine(tax_year_data_loader=lambda y, p="ON": YEAR_2025)
+    params = StrategyParamsInput(cpp_start_age=70, oas_start_age=70)
+    yearly, summary = engine.run(StrategyCodeEnum.CD, scenario, params)
+
+    assert yearly[0].income_sources.rrif_withdrawal > 0
+    assert summary.lifetime_tax_paid_nominal > 0

--- a/backend/tests/unit/services/strategy_engine/strategies/test_early_rrif_conversion.py
+++ b/backend/tests/unit/services/strategy_engine/strategies/test_early_rrif_conversion.py
@@ -1,1 +1,19 @@
-# TODO: Implement Python module
+from copy import deepcopy
+
+from app.data_models.scenario import (
+    ScenarioInput,
+    StrategyCodeEnum,
+    StrategyParamsInput,
+)
+from app.services.strategy_engine.engine import StrategyEngine
+from backend.tests.conftest import YEAR_2025
+
+
+def test_early_rrif_conversion_minimum_withdrawal_and_tax():
+    scenario = ScenarioInput(**deepcopy(ScenarioInput.Config.json_schema_extra["example"]))
+    engine = StrategyEngine(tax_year_data_loader=lambda y, p="ON": YEAR_2025)
+    params = StrategyParamsInput(rrif_conversion_age=65)
+    yearly, summary = engine.run(StrategyCodeEnum.E65, scenario, params)
+
+    assert yearly[0].income_sources.rrif_withdrawal > 0
+    assert summary.lifetime_tax_paid_nominal > 0

--- a/backend/tests/unit/services/strategy_engine/strategies/test_interest_offset_loan.py
+++ b/backend/tests/unit/services/strategy_engine/strategies/test_interest_offset_loan.py
@@ -1,1 +1,22 @@
-# TODO: Implement Python module
+from copy import deepcopy
+
+from app.data_models.scenario import (
+    ScenarioInput,
+    StrategyCodeEnum,
+    StrategyParamsInput,
+)
+from app.services.strategy_engine.engine import StrategyEngine
+from backend.tests.conftest import YEAR_2025
+
+
+def test_interest_offset_loan_positive_withdrawal_and_tax():
+    scenario = ScenarioInput(**deepcopy(ScenarioInput.Config.json_schema_extra["example"]))
+    engine = StrategyEngine(tax_year_data_loader=lambda y, p="ON": YEAR_2025)
+    params = StrategyParamsInput(
+        loan_interest_rate_pct=5.0,
+        loan_amount_as_pct_of_rrif=20.0,
+    )
+    yearly, summary = engine.run(StrategyCodeEnum.IO, scenario, params)
+
+    assert yearly[0].income_sources.rrif_withdrawal > 0
+    assert summary.lifetime_tax_paid_nominal > 0


### PR DESCRIPTION
## Summary
- add simple regression tests for bracket filling, CPP/OAS delay,
  early RRIF conversion and interest offset strategies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*