### PR TITLE
Clamp negative income for interest offset

### DIFF
--- a/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
+++ b/backend/app/services/strategy_engine/strategies/interest_offset_loan.py
@@ -176,7 +176,9 @@ class InterestOffsetStrategy(BaseStrategy):
                 cpp=cpp,
                 oas_gross=oas_gross,
                 db_pension=db_pension,
-                other_taxable_income=taxable_nonreg_income - interest_exp,
+                other_taxable_income=max(
+                    Decimal("0"), taxable_nonreg_income - interest_exp
+                ),
                 taxable_income=taxable_income,
                 fed_tax=tr["federal_tax"],
                 prov_tax=tr["provincial_tax"],


### PR DESCRIPTION
## Summary
- avoid Pydantic validation errors in interest-offset strategy by clamping `other_taxable_income`

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683a6161d1e083269d0fff39f9d3d56b