### PR TITLE
Move httpx to production dependencies

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,11 +29,11 @@ openai = "^1.78.1"
 redis = "^6.1.0"
 sqlalchemy = {version = "^2.0", extras = ["asyncio"]}
 aiosqlite = "^0.21.0"
+httpx = "^0.24.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"
 pytest-asyncio = "^0.21.0"
-httpx = "^0.24.0" # For testing API calls
 ruff = "^0.0.285" # For linting
 
 [build-system]


### PR DESCRIPTION
## Summary
- move `httpx` from dev to main dependencies in backend `pyproject.toml`

## Testing
- `poetry lock` *(fails: All attempts to connect to pypi.org failed)*

------
https://chatgpt.com/codex/tasks/task_e_68479553333c8326949498438d819abf