### PR TITLE
Add Gemini env var docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ The consolidated tax tables live in `backend/data/tax_years.yml`.  Additional
 per‑year files are stored under the top‑level `tax/` directory.  These YAML files
 are parsed at runtime by the backend via PyYAML.
 
+## Environment variables
+
+The backend reads optional settings from a `.env` file in the `backend` directory. To use the Gemini-based explanation features, provide a Google API key and model name, for example:
+
+```
+GEMINI_API_KEY=your-gemini-api-key
+GEMINI_MODEL=gemini-pro
+```
+
+`GEMINI_MODEL` defaults to `gemini-pro` if left unset.
+
+
 ## Running tests
 
 ### Backend

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,6 +8,18 @@ The backend reads tax tables from YAML files. A real installation of
 **PyYAML** is therefore required. Continuous integration checks that
 `import yaml` succeeds, and `poetry install` will provide the package.
 
+## Environment variables
+
+Create a `.env` file in this directory with your Gemini configuration:
+
+```
+GEMINI_API_KEY=your-gemini-api-key
+GEMINI_MODEL=gemini-pro
+```
+
+`GEMINI_MODEL` defaults to `gemini-pro` if omitted.
+
+
 ## Debug API
 
 For troubleshooting, the backend exposes a debug route listing registered


### PR DESCRIPTION
## Summary
- document GEMINI_API_KEY and GEMINI_MODEL in the project README
- add the same environment variable notes to the backend README

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847963d51e88326ae92fdc4b0ce96da