### PR TITLE
Implement LLM explanation endpoint

### DIFF
--- a/backend/app/api/v1/explain.py
+++ b/backend/app/api/v1/explain.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from app.data_models.scenario import ScenarioInput, StrategyCodeEnum, GoalEnum
+from app.data_models.results import SummaryMetrics
+from app.services.llm_service import explain_strategy_with_context
+
+router = APIRouter(prefix="/api/v1", tags=["explain"])
+
+
+class ExplainRequest(BaseModel):
+    scenario: ScenarioInput
+    strategy_code: StrategyCodeEnum
+    summary: SummaryMetrics
+    goal: GoalEnum
+
+
+class ExplainResponse(BaseModel):
+    explanation: str
+
+
+@router.post("/explain", response_model=ExplainResponse)
+async def explain(req: ExplainRequest) -> ExplainResponse:
+    text = await explain_strategy_with_context(
+        req.scenario, req.strategy_code, req.summary, req.goal
+    )
+    return ExplainResponse(explanation=text)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -69,8 +69,10 @@ app.add_middleware(
 # include v1 simulation router (defined in app/api/v1/simulate.py)
 # ------------------------------------------------------------------ #
 from app.api.v1.simulate import router as simulate_router  # noqa: E402  (import after FastAPI instantiated)
+from app.api.v1.explain import router as explain_router  # noqa: E402
 
 app.include_router(simulate_router)
+app.include_router(explain_router)
 
 # ------------------------------------------------------------------ #
 # database init (runs once at start-up)

--- a/backend/tests/integration/api/v1/test_explain.py
+++ b/backend/tests/integration/api/v1/test_explain.py
@@ -1,0 +1,41 @@
+import pytest
+
+from app.data_models.scenario import ScenarioInput, StrategyCodeEnum, GoalEnum
+from app.data_models.results import SummaryMetrics
+from app.core.config import settings
+
+EXAMPLE_SCENARIO = ScenarioInput.Config.json_schema_extra["example"]
+EXAMPLE_SUMMARY = SummaryMetrics.Config.json_schema_extra["example"]
+
+
+@pytest.mark.asyncio
+async def test_explain_endpoint(client, monkeypatch):
+    monkeypatch.setattr(settings, "GEMINI_API_KEY", "fake-key")
+
+    async def fake_post(self, url, json):
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "candidates": [
+                        {"content": {"parts": [{"text": "sample explanation"}]}}
+                    ]
+                }
+
+        return _Resp()
+
+    monkeypatch.setattr("httpx.AsyncClient.post", fake_post)
+
+    payload = {
+        "scenario": EXAMPLE_SCENARIO,
+        "strategy_code": StrategyCodeEnum.GM.value,
+        "summary": EXAMPLE_SUMMARY,
+        "goal": GoalEnum.MAXIMIZE_SPENDING.value,
+    }
+    resp = await client.post("/api/v1/explain", json=payload)
+    assert resp.status_code == 200
+    assert resp.json() == {"explanation": "sample explanation"}


### PR DESCRIPTION
## Summary
- add `/explain` API route in `backend/app/api/v1`
- register explain router with the FastAPI app
- test explanation endpoint with mocked Gemini client

## Testing
- `ruff check .` *(fails: unrecognized or uses internal settings?)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6847974b35888326aa7ea3ee214a4d82