### PR TITLE
Add explanation fetch to results page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import StrategyStep from "./components/StrategyStep";
 import InputFormStep from "./components/InputFormStep";
 import ResultsPage from "./components/ResultsPage";
 import type { FormData } from "./types/formData";
-import type { ComparisonResponseItem } from "./types/api";
+import type { ComparisonResponseItem, ScenarioInput } from "./types/api";
 
 /* ------------------------------------------------------------------ */
 const App: React.FC = () => {
@@ -30,6 +30,7 @@ const App: React.FC = () => {
   const [resultsData, setResultsData] = useState<ComparisonResponseItem[] | null>(
     null,
   );
+  const [scenarioData, setScenarioData] = useState<ScenarioInput | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   /* helpers --------------------------------------------------------- */
@@ -87,6 +88,7 @@ const App: React.FC = () => {
         target_depletion_age: formData.emptyByAge,
       },
     };
+    setScenarioData(scenarioPayload as ScenarioInput);
 
     /* ----------------------------------------------
      * 3) Decide which strategies to run
@@ -181,6 +183,7 @@ const App: React.FC = () => {
             strategies={formData.strategies}
             horizon={formData.horizon}
             results={resultsData}
+            scenario={scenarioData}
             onBack={() => {
               setResultsData(null);
               setCurrentStep(2);

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -40,6 +40,22 @@ export interface StrategiesResponse {
   recommended: string[];
 }
 
+export interface ScenarioInput {
+  age: number;
+  rrsp_balance: number;
+  tfsa_balance: number;
+  cpp_at_65: number;
+  oas_at_65: number;
+  desired_spending: number;
+  expect_return_pct: number;
+  stddev_return_pct: number;
+  life_expectancy_years: number;
+  province: string;
+  goal: GoalEnum;
+  spouse?: SpouseInfo;
+  strategy_params_override?: StrategyParamsInput;
+}
+
 export interface SummaryMetrics {
   lifetime_tax_paid_nominal: number;
   lifetime_tax_paid_pv: number;
@@ -69,5 +85,16 @@ export interface ComparisonResponseItem {
   total_taxes?: number;
   total_spending?: number;
   final_estate?: number;
+}
+
+export interface ExplainRequest {
+  scenario: ScenarioInput;
+  strategy_code: string;
+  summary: SummaryMetrics;
+  goal: GoalEnum;
+}
+
+export interface ExplainResponse {
+  explanation: string;
 }
 


### PR DESCRIPTION
## Summary
- add ScenarioInput and explanation types
- store scenario data in `App` and pass into `ResultsPage`
- call `/api/v1/explain` when recommendations are shown and render returned text

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847982ed3148326ad26dfb6909f546b