### PR TITLE
Remove unused OpenAI dependency

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -73,8 +73,6 @@ class Settings(BaseSettings):
     # ------------------------------------------------------------------ #
     # LLM
     # ------------------------------------------------------------------ #
-    OPENAI_API_KEY: Optional[str] = Field(default=None, env="OPENAI_API_KEY")
-    OPENAI_MODEL: str = Field("gpt-4o-mini", env="OPENAI_MODEL")
     ANTHROPIC_API_KEY: Optional[str] = Field(default=None, env="ANTHROPIC_API_KEY")
     ANTHROPIC_MODEL: str = Field("claude-3-haiku-20240307", env="ANTHROPIC_MODEL")
     GEMINI_API_KEY: Optional[str] = Field(default=None, env="GEMINI_API_KEY")

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -796,33 +796,6 @@ files = [
 ]
 
 [[package]]
-name = "openai"
-version = "1.78.1"
-description = "The official Python library for the openai API"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "openai-1.78.1-py3-none-any.whl", hash = "sha256:7368bf147ca499804cc408fe68cdb6866a060f38dec961bbc97b04f9d917907e"},
-    {file = "openai-1.78.1.tar.gz", hash = "sha256:8b26b364531b100df1b961d03560042e5f5be11301d7d49a6cd1a2b9af824dca"},
-]
-
-[package.dependencies]
-anyio = ">=3.5.0,<5"
-distro = ">=1.7.0,<2"
-httpx = ">=0.23.0,<1"
-jiter = ">=0.4.0,<1"
-pydantic = ">=1.9.0,<3"
-sniffio = "*"
-tqdm = ">4"
-typing-extensions = ">=4.11,<5"
-
-[package.extras]
-datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
-realtime = ["websockets (>=13,<16)"]
-voice-helpers = ["numpy (>=2.0.2)", "sounddevice (>=0.5.1)"]
-
-[[package]]
 name = "packaging"
 version = "25.0"
 description = "Core utilities for Python packages"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,7 +25,6 @@ passlib = {extras = ["bcrypt"], version = "^1.7.4"} # For password hashing if ne
 PyYAML = "^6.0" # For reading YAML files
 numpy = "^1.25.0" # For Monte Carlo
 pandas = "^2.0.0" # For data manipulation in Monte Carlo
-openai = "^1.78.1"
 redis = "^6.1.0"
 sqlalchemy = {version = "^2.0", extras = ["asyncio"]}
 aiosqlite = "^0.21.0"


### PR DESCRIPTION
## Summary
- remove `openai` from poetry config
- update lock file accordingly
- drop OpenAI settings from backend config

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479f168ed48326b0fad27274210754