### PR TITLE
Switch LLM service to OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ are parsed at runtime by the backend via PyYAML.
 
 ## Environment variables
 
-The backend reads optional settings from a `.env` file in the `backend` directory. To use the Gemini-based explanation features, provide a Google API key and model name, for example:
+The backend reads optional settings from a `.env` file in the `backend` directory. To enable the explanation features, provide an OpenRouter API key and model name, for example:
 
 ```
-GEMINI_API_KEY=your-gemini-api-key
-GEMINI_MODEL=gemini-pro
+OPENROUTER_API_KEY=your-openrouter-key
+OPENROUTER_MODEL=openai/o4-mini
 ```
 
-`GEMINI_MODEL` defaults to `gemini-pro` if left unset.
+`OPENROUTER_MODEL` defaults to `openai/o4-mini` if left unset.
 
 
 ## Running tests

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,14 +10,14 @@ The backend reads tax tables from YAML files. A real installation of
 
 ## Environment variables
 
-Create a `.env` file in this directory with your Gemini configuration:
+Create a `.env` file in this directory with your OpenRouter configuration:
 
 ```
-GEMINI_API_KEY=your-gemini-api-key
-GEMINI_MODEL=gemini-pro
+OPENROUTER_API_KEY=your-openrouter-key
+OPENROUTER_MODEL=openai/o4-mini
 ```
 
-`GEMINI_MODEL` defaults to `gemini-pro` if omitted.
+`OPENROUTER_MODEL` defaults to `openai/o4-mini` if omitted.
 
 
 ## Debug API

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -77,6 +77,8 @@ class Settings(BaseSettings):
     ANTHROPIC_MODEL: str = Field("claude-3-haiku-20240307", env="ANTHROPIC_MODEL")
     GEMINI_API_KEY: Optional[str] = Field(default=None, env="GEMINI_API_KEY")
     GEMINI_MODEL: str = Field("gemini-pro", env="GEMINI_MODEL")
+    OPENROUTER_API_KEY: Optional[str] = Field(default=None, env="OPENROUTER_API_KEY")
+    OPENROUTER_MODEL: str = Field("openai/o4-mini", env="OPENROUTER_MODEL")
 
     # ------------------------------------------------------------------ #
     model_config = SettingsConfigDict(

--- a/backend/tests/integration/api/v1/test_explain.py
+++ b/backend/tests/integration/api/v1/test_explain.py
@@ -10,9 +10,9 @@ EXAMPLE_SUMMARY = SummaryMetrics.Config.json_schema_extra["example"]
 
 @pytest.mark.asyncio
 async def test_explain_endpoint(client, monkeypatch):
-    monkeypatch.setattr(settings, "GEMINI_API_KEY", "fake-key")
+    monkeypatch.setattr(settings, "OPENROUTER_API_KEY", "fake-key")
 
-    async def fake_post(self, url, json):
+    async def fake_post(self, url, headers=None, json=None):
         class _Resp:
             status_code = 200
 
@@ -21,8 +21,8 @@ async def test_explain_endpoint(client, monkeypatch):
 
             def json(self):
                 return {
-                    "candidates": [
-                        {"content": {"parts": [{"text": "sample explanation"}]}}
+                    "choices": [
+                        {"message": {"content": "sample explanation"}}
                     ]
                 }
 


### PR DESCRIPTION
## Summary
- swap Gemini-based explanation service for OpenRouter
- update config for `OPENROUTER_API_KEY` and default model `openai/o4-mini`
- adjust docs to reference the new LLM configuration
- update integration tests for new API call

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6848f23990b08326a37f384a65e0be5b