### PR TITLE
Sanitize explanation on results page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "yup": "^1.2.0",
     "classnames": "^2.3.2",
     "@floating-ui/dom": "^1.6.2",
-    "recharts": "^2.9.0"
+    "recharts": "^2.9.0",
+    "dompurify": "^3.0.3"
 
   },
   "devDependencies": {

--- a/frontend/src/components/ResultsPage.test.tsx
+++ b/frontend/src/components/ResultsPage.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import ResultsPage from './ResultsPage';
+import DOMPurify from 'dompurify';
+import type { ComparisonResponseItem, ScenarioInput } from '../types/api';
+
+jest.mock('dompurify', () => ({
+  __esModule: true,
+  default: { sanitize: jest.fn(() => 'cleaned') }
+}));
+
+const summary = {
+  lifetime_tax_paid_nominal: 0,
+  lifetime_tax_paid_pv: 0,
+  average_effective_tax_rate: 0,
+  years_in_oas_clawback: 0,
+  total_oas_clawback_paid_nominal: 0,
+  average_annual_real_spending: 0,
+  final_total_portfolio_value_nominal: 0,
+  final_total_portfolio_value_pv: 0,
+  net_value_to_heirs_after_final_taxes_pv: 0,
+  strategy_complexity_score: 0,
+};
+
+const result: ComparisonResponseItem = {
+  strategy_code: 'T',
+  strategy_name: 'Test',
+  summary,
+  total_taxes: 0,
+  total_spending: 0,
+  final_estate: 0,
+};
+
+const scenario: ScenarioInput = {
+  age: 65,
+  rrsp_balance: 0,
+  tfsa_balance: 0,
+  cpp_at_65: 0,
+  oas_at_65: 0,
+  desired_spending: 0,
+  expect_return_pct: 0,
+  stddev_return_pct: 0,
+  life_expectancy_years: 30,
+  province: 'ON',
+  goal: 'minimize_tax',
+};
+
+beforeEach(() => {
+  (DOMPurify.sanitize as jest.Mock).mockClear();
+});
+
+test('sanitizes explanation HTML before rendering', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ explanation: '<script>alert(1)</script>' }),
+  }) as jest.Mock;
+
+  render(
+    <ResultsPage
+      goal="Minimize Tax"
+      strategies={[result.strategy_code]}
+      horizon={30}
+      results={[result]}
+      scenario={scenario}
+      onBack={() => {}}
+      onStartOver={() => {}}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(DOMPurify.sanitize).toHaveBeenCalledWith('<script>alert(1)</script>');
+  });
+
+  expect(screen.getByText('cleaned')).toBeInTheDocument();
+});

--- a/frontend/src/components/ResultsPage.tsx
+++ b/frontend/src/components/ResultsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useEffect, useState } from 'react';
+import DOMPurify from 'dompurify';
 import {
   Box,
   Typography,
@@ -148,7 +149,11 @@ const ResultsPage: React.FC<ResultsPageProps> = ({
           </Typography>
         )}
         {explanation && (
-          <Typography variant="body2" gutterBottom>{explanation}</Typography>
+          <Typography
+            variant="body2"
+            gutterBottom
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(explanation) }}
+          />
         )}
       <Typography variant="body1" gutterBottom>
         Based on your goal (<em>{goal}</em>), the strategy above is projected to perform the best among those selected.


### PR DESCRIPTION
## Summary
- sanitize explanation HTML with DOMPurify in ResultsPage
- add DOMPurify to frontend dependencies
- test that DOMPurify is used when explanation loads

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a37ed20008326a95640fda8887f4e