### PR TITLE
Update explain endpoint to return structured JSON

### DIFF
--- a/backend/app/api/v1/explain.py
+++ b/backend/app/api/v1/explain.py
@@ -16,12 +16,14 @@ class ExplainRequest(BaseModel):
 
 
 class ExplainResponse(BaseModel):
-    explanation: str
+    summary: str
+    key_outcomes: list[str]
+    recommendations: str
 
 
 @router.post("/explain", response_model=ExplainResponse)
 async def explain(req: ExplainRequest) -> ExplainResponse:
-    text = await explain_strategy_with_context(
+    data = await explain_strategy_with_context(
         req.scenario, req.strategy_code, req.summary, req.goal
     )
-    return ExplainResponse(explanation=text)
+    return ExplainResponse(**data)

--- a/backend/tests/integration/api/v1/test_explain.py
+++ b/backend/tests/integration/api/v1/test_explain.py
@@ -22,7 +22,11 @@ async def test_explain_endpoint(client, monkeypatch):
             def json(self):
                 return {
                     "choices": [
-                        {"message": {"content": "sample explanation"}}
+                        {
+                            "message": {
+                                "content": '{"summary": "s", "key_outcomes": ["o"], "recommendations": "r"}'
+                            }
+                        }
                     ]
                 }
 
@@ -38,4 +42,8 @@ async def test_explain_endpoint(client, monkeypatch):
     }
     resp = await client.post("/api/v1/explain", json=payload)
     assert resp.status_code == 200
-    assert resp.json() == {"explanation": "sample explanation"}
+    assert resp.json() == {
+        "summary": "s",
+        "key_outcomes": ["o"],
+        "recommendations": "r",
+    }


### PR DESCRIPTION
## Summary
- modify llm_service to request JSON and parse response
- adjust ExplainResponse model fields
- update integration test for new structure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684a38d62d1c8326af753f1ae1f55906