### PR TITLE
Improve Results table formatting

### DIFF
--- a/frontend/src/components/ReportPage.tsx
+++ b/frontend/src/components/ReportPage.tsx
@@ -14,6 +14,12 @@ import { useReactToPrint } from 'react-to-print';
 import StrategyChart from './StrategyChart';
 import type { ComparisonResponseItem, ExplainResponse } from '../types/api';
 
+const currencyFormatter = new Intl.NumberFormat('en-CA', {
+  style: 'currency',
+  currency: 'CAD',
+  maximumFractionDigits: 0,
+});
+
 interface ReportPageProps {
   goal: string;
   horizon: number;
@@ -126,7 +132,7 @@ const ReportPage: React.FC<ReportPageProps> = ({
           <Typography variant="h6" gutterBottom>
             Projection Horizon: {horizon} years
           </Typography>
-          <Table size="small" sx={{ my: 2 }}>
+          <Table size="small" sx={{ my: 2 }} className="w-full report-table">
             <TableHead>
               <TableRow>
                 <TableCell>Strategy</TableCell>
@@ -141,17 +147,17 @@ const ReportPage: React.FC<ReportPageProps> = ({
                   <TableCell>{res.strategy_name}</TableCell>
                   <TableCell align="right">
                     {res.totalTaxes !== null
-                      ? `$${res.totalTaxes.toLocaleString()}`
+                      ? currencyFormatter.format(res.totalTaxes)
                       : '—'}
                   </TableCell>
                   <TableCell align="right">
                     {res.totalSpending !== null
-                      ? `$${res.totalSpending.toLocaleString()}`
+                      ? currencyFormatter.format(res.totalSpending)
                       : '—'}
                   </TableCell>
                   <TableCell align="right">
                     {res.finalEstate !== null
-                      ? `$${res.finalEstate.toLocaleString()}`
+                      ? currencyFormatter.format(res.finalEstate)
                       : '—'}
                   </TableCell>
                 </TableRow>

--- a/frontend/src/components/ResultsPage.tsx
+++ b/frontend/src/components/ResultsPage.tsx
@@ -13,6 +13,12 @@ import {
 import StrategyChart from './StrategyChart';
 import ReportPage from './ReportPage';
 
+const currencyFormatter = new Intl.NumberFormat('en-CA', {
+  style: 'currency',
+  currency: 'CAD',
+  maximumFractionDigits: 0,
+});
+
 import type {
   ComparisonResponseItem,
   ScenarioInput,
@@ -178,7 +184,7 @@ const ResultsPage: React.FC<ResultsPageProps> = ({
       </Typography>
 
       {/* Comparison Table for selected strategies */}
-      <Table size="small" sx={{ my: 2 }}>
+      <Table size="small" sx={{ my: 2 }} className="w-full report-table">
         <TableHead>
           <TableRow>
             <TableCell>Strategy</TableCell>
@@ -203,13 +209,13 @@ const ResultsPage: React.FC<ResultsPageProps> = ({
             >
               <TableCell>{res.strategy_name}</TableCell>
               <TableCell align="right">
-                {res.totalTaxes !== null ? `$${res.totalTaxes.toLocaleString()}` : '—'}
+                {res.totalTaxes !== null ? currencyFormatter.format(res.totalTaxes) : '—'}
               </TableCell>
               <TableCell align="right">
-                {res.totalSpending !== null ? `$${res.totalSpending.toLocaleString()}` : '—'}
+                {res.totalSpending !== null ? currencyFormatter.format(res.totalSpending) : '—'}
               </TableCell>
               <TableCell align="right">
-                {res.finalEstate !== null ? `$${res.finalEstate.toLocaleString()}` : '—'}
+                {res.finalEstate !== null ? currencyFormatter.format(res.finalEstate) : '—'}
               </TableCell>
             </TableRow>
           ))}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,3 +11,23 @@
     display: none;
   }
 }
+
+.report-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.report-table th,
+.report-table td {
+  padding: 0.25rem 0.5rem;
+}
+
+@media print {
+  .report-table th,
+  .report-table td {
+    border: 1px solid black;
+  }
+  .report-table thead {
+    background-color: #f0f0f0;
+  }
+}


### PR DESCRIPTION
## Summary
- format currency values with `Intl.NumberFormat`
- style comparison table for better print layout

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3b6c0c2c8326a36d5aee4cd88234